### PR TITLE
🐛 don't require operation name

### DIFF
--- a/src/setupEmbedRelay.ts
+++ b/src/setupEmbedRelay.ts
@@ -43,7 +43,7 @@ async function executeOperation({
   operation: string;
   operationId: string;
   embeddedExplorerIFrameElement: HTMLIFrameElement;
-  operationName?: string;
+  operationName: string | undefined;
   variables?: Record<string, string>;
   headers?: Record<string, string>;
 }) {


### PR DESCRIPTION
Operation name isn't required for operations :) whoops!