### PR TITLE
Clean up event listeners when re-initializing the embedded explorer object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "embeddable-explorer",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,6 @@
 import type { IntrospectionQuery } from 'graphql';
-import { HandleRequest, executeOperation } from './setupEmbedRelay';
-import {
-  EMBEDDABLE_EXPLORER_URL,
-  EXPLORER_LISTENING_FOR_SCHEMA,
-  EXPLORER_QUERY_MUTATION_REQUEST,
-  SCHEMA_RESPONSE,
-} from './constants';
+import { EMBEDDABLE_EXPLORER_URL } from './constants';
+import { HandleRequest, setupEmbedRelay } from './setupEmbedRelay';
 
 type EmbeddableExplorerOptions = {
   target: string | HTMLElement; // HTMLElement is to accomodate people who might prefer to pass in a ref
@@ -57,24 +52,22 @@ type InternalEmbeddableExplorerOptions = {
   | { schema: string | IntrospectionQuery; graphRef: never }
 );
 
-let wtf: Function | undefined;
-
 class EmbeddedExplorer {
   options: InternalEmbeddableExplorerOptions;
   handleRequest: HandleRequest;
   embeddedExplorerURL: string;
-  embeddedExplorerIFrameElement: HTMLIFrameElement
-  id: number;
-
   constructor(options: EmbeddableExplorerOptions) {
     this.options = options as InternalEmbeddableExplorerOptions;
     this.validateOptions();
-    this.id = new Date().getTime();
     this.handleRequest = this.options.handleRequest ?? fetch;
     this.embeddedExplorerURL = this.getEmbeddedExplorerURL();
-    this.embeddedExplorerIFrameElement = this.injectEmbed();
-    
-    this.setupEmbedRelay();
+    const embeddedExplorerIFrameElement = this.injectEmbed();
+    setupEmbedRelay({
+      embeddedExplorerIFrameElement,
+      endpointUrl: this.options.endpointUrl,
+      handleRequest: this.handleRequest,
+      schema: 'schema' in this.options ? this.options.schema : undefined,
+    });
   }
 
   injectEmbed() {
@@ -96,69 +89,6 @@ class EmbeddedExplorer {
 
     return iframeElement;
   }
-
-  setupEmbedRelay = () => {
-    // Callback definition
-    
-    // Execute our callback whenever window.postMessage is called
-    if (wtf) {
-      // @ts-ignore
-      window.removeEventListener('message', wtf);
-    }
-    window.addEventListener('message', this.onPostMessageReceived);
-    wtf = this.onPostMessageReceived;
-  }
-
-  onPostMessageReceived = (event: MessageEvent) => {
-    console.log('message received: ', event, this);
-    const data: {
-      name: string;
-      operationName?: string;
-      operation: string;
-      operationId: string;
-      variables?: Record<string, string>;
-      headers?: Record<string, string>;
-    } = event.data;  
-    const schema = 'schema' in this.options ? this.options.schema : undefined;
-    // Embedded Explorer sends us a PM when it is ready for a schema
-    if (
-      'name' in data &&
-      data.name === EXPLORER_LISTENING_FOR_SCHEMA &&
-      !!schema
-    ) {
-      this.embeddedExplorerIFrameElement.contentWindow?.postMessage(
-        {
-          name: SCHEMA_RESPONSE,
-          schema,
-        },
-        EMBEDDABLE_EXPLORER_URL
-      );
-    }
-
-    // Check to see if the posted message indicates that the user is
-    // executing a query or mutation or subscription in the Explorer
-    const isQueryOrMutation =
-      'name' in data && data.name === EXPLORER_QUERY_MUTATION_REQUEST;
-
-    // If the user is executing a query or mutation or subscription...
-    if (isQueryOrMutation && data.operation && data.operationId) {
-      // Extract the operation details from the event.data object
-      const { operation, operationId, operationName, variables, headers } =
-        data;
-      if (isQueryOrMutation) {
-        executeOperation({
-          endpointUrl: this.options.endpointUrl,
-          handleRequest: this.handleRequest,
-          operation,
-          operationName,
-          variables,
-          headers,
-          embeddedExplorerIFrameElement: this.embeddedExplorerIFrameElement,
-          operationId,
-        });
-      }
-    }
-  };
 
   validateOptions() {
     if (!this.options.target) {

--- a/src/setupEmbedRelay.ts
+++ b/src/setupEmbedRelay.ts
@@ -1,6 +1,10 @@
+import type { IntrospectionQuery } from 'graphql';
 import {
   EMBEDDABLE_EXPLORER_URL,
+  EXPLORER_LISTENING_FOR_SCHEMA,
+  EXPLORER_QUERY_MUTATION_REQUEST,
   EXPLORER_QUERY_MUTATION_RESPONSE,
+  SCHEMA_RESPONSE,
 } from './constants';
 
 export type HandleRequest = (
@@ -24,7 +28,9 @@ function getHeadersWithContentType(
   return headersWithContentType;
 }
 
-export function executeOperation({
+let eventListenerHandler: ((event: MessageEvent) => void) | undefined;
+
+function executeOperation({
   endpointUrl,
   handleRequest,
   operation,
@@ -67,4 +73,73 @@ export function executeOperation({
         EMBEDDABLE_EXPLORER_URL
       );
     });
+}
+
+export function setupEmbedRelay({
+  endpointUrl,
+  handleRequest,
+  embeddedExplorerIFrameElement,
+  schema,
+}: {
+  endpointUrl: string;
+  handleRequest: HandleRequest;
+  embeddedExplorerIFrameElement: HTMLIFrameElement;
+  schema?: string | IntrospectionQuery | undefined;
+}) {
+  // Callback definition
+  const onPostMessageReceived = (event: MessageEvent) => {
+    const data: {
+      name: string;
+      operationName?: string;
+      operation: string;
+      operationId: string;
+      variables?: Record<string, string>;
+      headers?: Record<string, string>;
+    } = event.data;
+    // Embedded Explorer sends us a PM when it is ready for a schema
+    if (
+      'name' in data &&
+      data.name === EXPLORER_LISTENING_FOR_SCHEMA &&
+      !!schema
+    ) {
+      embeddedExplorerIFrameElement.contentWindow?.postMessage(
+        {
+          name: SCHEMA_RESPONSE,
+          schema,
+        },
+        EMBEDDABLE_EXPLORER_URL
+      );
+    }
+
+    // Check to see if the posted message indicates that the user is
+    // executing a query or mutation or subscription in the Explorer
+    const isQueryOrMutation =
+      'name' in data && data.name === EXPLORER_QUERY_MUTATION_REQUEST;
+
+    // If the user is executing a query or mutation or subscription...
+    if (isQueryOrMutation && data.operation && data.operationId) {
+      // Extract the operation details from the event.data object
+      const { operation, operationId, operationName, variables, headers } =
+        data;
+      if (isQueryOrMutation) {
+        executeOperation({
+          endpointUrl,
+          handleRequest,
+          operation,
+          operationName,
+          variables,
+          headers,
+          embeddedExplorerIFrameElement,
+          operationId,
+        });
+      }
+    }
+  };
+  // Execute our callback whenever window.postMessage is called
+  if (eventListenerHandler) {
+    window.removeEventListener('message', eventListenerHandler);
+    eventListenerHandler = undefined;
+  }
+  window.addEventListener('message', onPostMessageReceived);
+  eventListenerHandler = onPostMessageReceived;
 }


### PR DESCRIPTION
I have a use-case in which users can select from a list of pre-defined templates that will re-create the explorer object with new default params. However, there's a memory leak in which the event listeners aren't cleaned up, so every time the explorer is created, n+1 network calls are made. This probably needs to fixed in a better way (allow this behavior without re-creating the embedded explorer), but it works for now.