### PR TITLE
🐛 keep built files name consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-
   "name": "@apollo/explorer",
   "version": "0.1.0",
   "author": "packages@apollographql.com",
@@ -16,7 +15,7 @@
   },
   "scripts": {
     "start": "tsdx watch",
-    "build": "tsdx build --format cjs,esm,umd",
+    "build": "tsdx build --format cjs,esm,umd --name embeddable-explorer",
     "test": "tsdx test --passWithNoTests",
     "lint": "tsdx lint",
     "prepare": "tsdx build",


### PR DESCRIPTION
[Ben renamed the name of the embeddable explorer repo](https://github.com/apollographql/embeddable-explorer/pull/13) in package.json to @apollo/explorer before he published to npm. That changed the generated files to prefix with `explorer...` instead of `embeddable-explorer...` [seen here](https://console.cloud.google.com/storage/browser/embeddable-explorer/_latest?project=mdg-services&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false). This means folks are embedding and being told to embed
```
<script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js"></script> 
<script>
  new window.EmbeddedExplorer({
```
which exists but is out of date.

This PR explicitly passes a name, instead of defaulting to the package name.