### PR TITLE
Group `size-limit` dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,5 +17,9 @@
       matchUpdateTypes: ['patch', 'minor'],
       groupSlug: 'all-minor-patch',
     },
+    {
+      groupName: 'size-limit',
+      matchPackagePatterns: ['size-limit']
+    },
   ],
 }


### PR DESCRIPTION
Renovate PR https://github.com/apollographql/embeddable-explorer/pull/35 is failing because of peer dependency issues - `size-limit` updates need to be grouped in order for this to work. This should result in a renovate PR which updates both `size-limit` and `@size-limit/file` at the same time.