### PR TITLE
Make `currentEmbed` a ref

### DIFF
--- a/.changeset/late-turtles-rush.md
+++ b/.changeset/late-turtles-rush.md
@@ -1,0 +1,5 @@
+---
+'@apollo/explorer': patch
+---
+
+Fix a react bug where there might be two embeds showing up instead of one.

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   EmbeddedExplorer,
   EmbeddableExplorerOptions,
@@ -11,21 +11,18 @@ export function ApolloExplorerReact(
 ) {
   const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>();
 
-  const [currentEmbed, setCurrentEmbed] = useState<EmbeddedExplorer>();
+  const currentEmbedRef = useRef<EmbeddedExplorer>();
 
   useEffect(() => {
     if (!wrapperElement) return;
+    currentEmbedRef.current?.dispose();
 
-    setCurrentEmbed((prevEmbed) => {
-      prevEmbed?.dispose();
-
-      return new EmbeddedExplorer({
-        ...props,
-        target: wrapperElement,
-      });
+    currentEmbedRef.current = new EmbeddedExplorer({
+      ...props,
+      target: wrapperElement,
     });
 
-    return () => currentEmbed?.dispose();
+    return () => currentEmbedRef.current?.dispose();
   }, [props, wrapperElement]);
 
   return (


### PR DESCRIPTION
I noticed 2 embeds for react showing up in the example code sandbox: https://codesandbox.io/s/npm-embeddable-explorer-zotwkv?file=/src/index.js

Should have caught this with the lint warnings!