### PR TITLE
Expose schema as an option to pass & remove sendRequestsFrom

### DIFF
--- a/.changeset/green-geese-play.md
+++ b/.changeset/green-geese-play.md
@@ -1,0 +1,5 @@
+---
+'@apollo/explorer': patch
+---
+
+Expose hidden field schema on ApolloExplorerReact

--- a/src/EmbeddedExplorer.ts
+++ b/src/EmbeddedExplorer.ts
@@ -4,28 +4,6 @@ import { HandleRequest, setupEmbedRelay } from './setupEmbedRelay';
 
 export type EmbeddableExplorerOptions = {
   target: string | HTMLElement; // HTMLElement is to accomodate people who might prefer to pass in a ref
-  graphRef: string;
-
-  initialState?: {
-    document?: string;
-    variables?: Record<string, any>;
-    headers?: Record<string, string>;
-    displayOptions: {
-      docsPanelState?: 'open' | 'closed'; // default to 'open',
-      showHeadersAndEnvVars?: boolean; // default to `false`
-      theme?: 'dark' | 'light';
-    };
-  };
-  persistExplorerState?: boolean; // defaults to 'false'
-
-  endpointUrl: string;
-
-  // optional. defaults to `return fetch(url, fetchOptions)`
-  handleRequest?: HandleRequest;
-};
-
-type InternalEmbeddableExplorerOptions = {
-  target: string | HTMLElement; // HTMLElement is to accomodate people who might prefer to pass in a ref
 
   initialState?: {
     document?: string;
@@ -53,12 +31,12 @@ type InternalEmbeddableExplorerOptions = {
 );
 
 export class EmbeddedExplorer {
-  options: InternalEmbeddableExplorerOptions;
+  options: EmbeddableExplorerOptions;
   handleRequest: HandleRequest;
   embeddedExplorerURL: string;
   private disposable: { dispose: () => void };
   constructor(options: EmbeddableExplorerOptions) {
-    this.options = options as InternalEmbeddableExplorerOptions;
+    this.options = options as EmbeddableExplorerOptions;
     this.validateOptions();
     this.handleRequest = this.options.handleRequest ?? fetch;
     this.embeddedExplorerURL = this.getEmbeddedExplorerURL();

--- a/src/EmbeddedExplorer.ts
+++ b/src/EmbeddedExplorer.ts
@@ -21,10 +21,6 @@ export type EmbeddableExplorerOptions = {
 
   // optional. defaults to `return fetch(url, fetchOptions)`
   handleRequest?: HandleRequest;
-
-  // optional. defaults to "parent". don't include in public docs yet
-  // throws error if value is 'embed' and `handleRequest` is provided
-  sendRequestsFrom?: 'parent' | 'embed';
 } & (
   | { graphRef: string; schema: never }
   | { schema: string | IntrospectionQuery; graphRef: never }
@@ -87,15 +83,6 @@ export class EmbeddedExplorer {
       );
     }
 
-    if (
-      this.options.handleRequest &&
-      this.options.sendRequestsFrom === 'embed'
-    ) {
-      throw new Error(
-        'You cannot pass a custom `handleRequest` if you have `sendRequestsFrom` set to "embed"'
-      );
-    }
-
     if ('schema' in this.options && 'graphRef' in this.options) {
       throw new Error(
         'Both `schema` and `graphRef` cannot be set. You can either send your schema as an IntrospectionQuery or string via the `schema` field, or specifiy a public graphRef.'
@@ -106,7 +93,7 @@ export class EmbeddedExplorer {
   getEmbeddedExplorerURL = () => {
     const { document, variables, headers, displayOptions } =
       this.options.initialState || {};
-    const { persistExplorerState, sendRequestsFrom } = this.options;
+    const { persistExplorerState } = this.options;
     const graphRef =
       'graphRef' in this.options ? this.options.graphRef : undefined;
     const queryParams = {
@@ -119,7 +106,7 @@ export class EmbeddedExplorer {
         ? encodeURIComponent(JSON.stringify(headers))
         : undefined,
       shouldPersistState: !!persistExplorerState,
-      sendRequestsFrom: sendRequestsFrom ?? 'parent',
+      sendRequestsFrom: 'parent',
       docsPanelState: displayOptions?.docsPanelState ?? 'open',
       showHeadersAndEnvVars: displayOptions?.showHeadersAndEnvVars !== false,
       theme: displayOptions?.theme ?? 'dark',

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,13 +1,30 @@
+import type { IntrospectionQuery } from 'graphql';
 import React, { useEffect, useRef, useState } from 'react';
 import {
+  BaseEmbeddableExplorerOptions,
   EmbeddedExplorer,
-  EmbeddableExplorerOptions,
 } from '../EmbeddedExplorer';
 
+// Need to extend from the base, b/c Omit<UnionType> doesn't carry over
+// the conditional never's established here
+interface EmbeddableExplorerOptionsWithSchema
+  extends Omit<BaseEmbeddableExplorerOptions, 'target'> {
+  schema: string | IntrospectionQuery;
+  graphRef?: never;
+}
+
+interface EmbeddableExplorerOptionsWithGraphRef
+  extends Omit<BaseEmbeddableExplorerOptions, 'target'> {
+  graphRef: string;
+  schema?: never;
+}
+
+export type EmbeddableExplorerOptions =
+  | EmbeddableExplorerOptionsWithSchema
+  | EmbeddableExplorerOptionsWithGraphRef;
+
 export function ApolloExplorerReact(
-  props: Omit<EmbeddableExplorerOptions, 'target'> & {
-    className?: string;
-  }
+  props: EmbeddableExplorerOptions & { className?: string }
 ) {
   const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>();
 


### PR DESCRIPTION
[JIRA](https://apollographql.atlassian.net/browse/NEBULA-1153)

Expose schema: Now that we are passing schema to the react component for the AS Landing Page v2: embed, we want to just allow this I imagine. No reason to hide it from folks anymore?

Remove sendRequestsFrom: this was never exposed, and I don't see a reason to keep it around. Now it becomes a security issue as well (see jira)
