### PR TITLE
NEBULA-1161: pm schema to embed when schema changes

### DIFF
--- a/.changeset/pink-geckos-behave.md
+++ b/.changeset/pink-geckos-behave.md
@@ -1,0 +1,5 @@
+---
+'@apollo/explorer': patch
+---
+
+PM schema to embed instead of rerendering

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@apollo/explorer",
       "version": "0.3.1",
       "license": "MIT",
+      "dependencies": {
+        "use-deep-compare-effect": "^1.8.1"
+      },
       "devDependencies": {
         "@changesets/changelog-github": "0.4.4",
         "@changesets/cli": "2.22.0",
@@ -1678,7 +1681,6 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
       "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -6531,6 +6533,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -10773,8 +10783,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -11299,7 +11308,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -12145,7 +12153,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13734,7 +13741,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13887,8 +13893,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -17304,6 +17309,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13"
+      }
+    },
     "node_modules/util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -19602,7 +19623,6 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
       "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -23576,6 +23596,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -26847,8 +26872,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -27276,7 +27300,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -27966,8 +27989,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -29122,7 +29144,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -29249,8 +29270,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -31933,6 +31953,15 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
+      }
     },
     "util": {
       "version": "0.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "use-deep-compare-effect": "^1.8.1",
-        "uuid": "^8.3.2"
+        "use-deep-compare-effect": "^1.8.1"
       },
       "devDependencies": {
         "@changesets/changelog-github": "0.4.4",
@@ -18,7 +17,6 @@
         "@size-limit/preset-small-lib": "5.0.5",
         "@types/react": "16.14.24",
         "@types/react-dom": "17.0.15",
-        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "5.19.0",
         "@typescript-eslint/parser": "5.19.0",
         "eslint": "8.13.0",
@@ -3838,12 +3836,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
-      "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -17364,14 +17356,6 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -21466,12 +21450,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "@types/yargs": {
@@ -32013,11 +31991,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "use-deep-compare-effect": "^1.8.1"
+        "use-deep-compare-effect": "^1.8.1",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@changesets/changelog-github": "0.4.4",
@@ -17,6 +18,7 @@
         "@size-limit/preset-small-lib": "5.0.5",
         "@types/react": "16.14.24",
         "@types/react-dom": "17.0.15",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "5.19.0",
         "@typescript-eslint/parser": "5.19.0",
         "eslint": "8.13.0",
@@ -3836,6 +3838,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -14104,6 +14112,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -17347,13 +17365,11 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -21450,6 +21466,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "@types/yargs": {
@@ -29399,6 +29421,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -31987,10 +32015,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "start": "tsdx watch",
+    "build": "npm run build:cjs-esm",
     "build:cjs-esm": "tsdx build --format cjs,esm --name embeddable-explorer",
     "build:umd": "tsdx build --format umd --entry src/index-umd.ts --name embeddable-explorer",
     "test": "tsdx test --passWithNoTests",
@@ -61,6 +62,7 @@
     "@size-limit/preset-small-lib": "5.0.5",
     "@types/react": "16.14.24",
     "@types/react-dom": "17.0.15",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "5.19.0",
     "@typescript-eslint/parser": "5.19.0",
     "eslint": "8.13.0",
@@ -92,6 +94,7 @@
     }
   },
   "dependencies": {
-    "use-deep-compare-effect": "^1.8.1"
+    "use-deep-compare-effect": "^1.8.1",
+    "uuid": "^8.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@size-limit/preset-small-lib": "5.0.5",
     "@types/react": "16.14.24",
     "@types/react-dom": "17.0.15",
-    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "5.19.0",
     "@typescript-eslint/parser": "5.19.0",
     "eslint": "8.13.0",
@@ -94,7 +93,6 @@
     }
   },
   "dependencies": {
-    "use-deep-compare-effect": "^1.8.1",
-    "uuid": "^8.3.2"
+    "use-deep-compare-effect": "^1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "react-dom": {
       "optional": true
     }
+  },
+  "dependencies": {
+    "use-deep-compare-effect": "^1.8.1"
   }
 }

--- a/src/EmbeddedExplorer.ts
+++ b/src/EmbeddedExplorer.ts
@@ -5,7 +5,6 @@ import {
   SCHEMA_RESPONSE,
 } from './constants';
 import { HandleRequest, setupEmbedRelay } from './setupEmbedRelay';
-import { v4 as uuid } from 'uuid';
 
 export interface BaseEmbeddableExplorerOptions {
   target: string | HTMLElement; // HTMLElement is to accomodate people who might prefer to pass in a ref
@@ -44,18 +43,20 @@ export type EmbeddableExplorerOptions =
   | EmbeddableExplorerOptionsWithSchema
   | EmbeddableExplorerOptionsWithGraphRef;
 
+let idCounter = 0;
+
 export class EmbeddedExplorer {
   options: EmbeddableExplorerOptions;
   handleRequest: HandleRequest;
   embeddedExplorerURL: string;
   embeddedExplorerIFrameElement: HTMLIFrameElement;
-  uniqueEmbedInstanceId: string;
+  uniqueEmbedInstanceId: number;
   private disposable: { dispose: () => void };
   constructor(options: EmbeddableExplorerOptions) {
     this.options = options;
     this.validateOptions();
     this.handleRequest = this.options.handleRequest ?? fetch;
-    this.uniqueEmbedInstanceId = uuid();
+    this.uniqueEmbedInstanceId = idCounter++;
     this.embeddedExplorerURL = this.getEmbeddedExplorerURL();
     this.embeddedExplorerIFrameElement = this.injectEmbed();
     this.disposable = setupEmbedRelay({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,5 +18,5 @@ export const EXPLORER_SUBSCRIPTION_REQUEST = 'ExplorerSubscriptionRequest';
 export const EXPLORER_SUBSCRIPTION_RESPONSE = 'ExplorerSubscriptionResponse';
 export const EXPLORER_SUBSCRIPTION_TERMINATION =
   'ExplorerSubscriptionTermination';
-export const IFRAME_DOM_ID = (uniqueId: string) =>
+export const IFRAME_DOM_ID = (uniqueId: number) =>
   `apollo-embedded-explorer-${uniqueId}`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,4 +18,5 @@ export const EXPLORER_SUBSCRIPTION_REQUEST = 'ExplorerSubscriptionRequest';
 export const EXPLORER_SUBSCRIPTION_RESPONSE = 'ExplorerSubscriptionResponse';
 export const EXPLORER_SUBSCRIPTION_TERMINATION =
   'ExplorerSubscriptionTermination';
-export const IFRAME_DOM_ID = 'apollo-embedded-explorer';
+export const IFRAME_DOM_ID = (uniqueId: string) =>
+  `apollo-embedded-explorer-${uniqueId}`;

--- a/src/examples/react-example/exampleSchema.ts
+++ b/src/examples/react-example/exampleSchema.ts
@@ -1,0 +1,268 @@
+export const exampleSchema = `"""
+The basic book in the graph
+"""
+type Book implements Product {
+  """
+  All books can be found by an isbn
+  """
+  isbn: String!
+
+  """
+  The title of the book
+  """
+  title: String
+
+  """
+  The year the book was published
+  """
+  year: Int
+
+  """
+  A simple list of similar books
+  """
+  similarBooks: [Book]
+
+  """
+  Since books are now products, we can also use their upc as a primary id
+  """
+  upc: String!
+
+  """
+  The name of a book is the book's title + year published
+  """
+  name(delimeter: String = " "): String
+  price: Int
+  weight: Int
+  reviews: [Review]
+  reviewList(first: Int = 5, after: Int = 0): ReviewConnection
+
+  """
+  relatedReviews for a book use the knowledge of similarBooks from the books
+  service to return related reviews that may be of interest to the user
+  """
+  relatedReviews(first: Int = 5, after: Int = 0): ReviewConnection
+}
+
+"""
+Information about the brand Ikea
+"""
+type Ikea {
+  """
+  Which asile to find an item
+  """
+  asile: Int
+}
+
+"""
+Information about the brand Amazon
+"""
+type Amazon {
+  """
+  The url of a referrer for a product
+  """
+  referrer: String
+}
+
+"""
+A union of all brands represented within the store
+"""
+union Brand = Ikea | Amazon
+
+enum ProductType {
+  LATEST
+  TRENDING
+}
+
+type PageInfo {
+  hasNextPage: Boolean
+  hasPreviousPage: Boolean
+}
+
+"""
+A connection edge for the Product type
+"""
+type ProductEdge {
+  product: Product
+}
+
+"""
+A connection wrapper for lists of products
+"""
+type ProductConnection {
+  """
+  Helpful metadata about the connection
+  """
+  pageInfo: PageInfo
+
+  """
+  List of products returned by the search
+  """
+  edges: [ProductEdge]
+}
+
+"""
+The Product type represents all products within the system
+"""
+interface Product {
+  """
+  The primary identifier of products in the graph
+  """
+  upc: String!
+
+  """
+  The display name of the product
+  """
+  name: String
+
+  """
+  A simple integer price of the product in US dollars
+  """
+  price: Int
+
+  """
+  How much the product weighs in kg
+  """
+  weight: Int @deprecated(reason: "Not all product's have a weight")
+
+  """
+  A simple list of all reviews for a product
+  """
+  reviews: [Review]
+    @deprecated(
+      reason: "The reviews field on product is deprecated to roll over the return type from a simple list to a paginated list. The easiest way to fix your operations is to alias the new field reviewList to review"
+    )
+
+  """
+  A paginated list of reviews. This field naming is temporary while all clients
+  migrate off of the un-paginated version of this field call reviews. To ease this migration,
+  alias your usage of reviewList to reviews so that after the roll over is finished, you
+  can remove the alias and use the final field name:
+
+    {
+      ... on Product {
+        reviews: reviewList {
+          edges {
+            review {
+              body
+            }
+          }
+        }
+      }
+    }
+  """
+  reviewList(first: Int = 5, after: Int = 0): ReviewConnection
+}
+
+"""
+The Furniture type represents all products which are items
+of furniture.
+"""
+type Furniture implements Product {
+  """
+  The modern primary identifier for furniture
+  """
+  upc: String!
+
+  """
+  The SKU field is how furniture was previously stored, and still exists in some legacy systems
+  """
+  sku: String!
+  name: String
+  price: Int
+
+  """
+  The brand of furniture
+  """
+  brand: Brand
+  weight: Int
+  reviews: [Review]
+  reviewList(first: Int = 5, after: Int = 0): ReviewConnection
+}
+
+"""
+The base User in Acephei
+"""
+type User {
+  """
+  A globally unique id for the user
+  """
+  id: ID!
+
+  """
+  The users full name as provided
+  """
+  name: String
+
+  """
+  The account username of the user
+  """
+  username: String
+
+  """
+  A list of all reviews by the user
+  """
+  reviews: [Review]
+}
+
+"""
+A review is any feedback about products across the graph
+"""
+type Review {
+  id: ID!
+
+  """
+  The plain text version of the review
+  """
+  body: String
+
+  """
+  The user who authored the review
+  """
+  author: User
+
+  """
+  The product which this review is about
+  """
+  product: Product
+}
+
+"""
+A connection edge for the Review type
+"""
+type ReviewEdge {
+  review: Review
+}
+
+"""
+A connection wrapper for lists of reviews
+"""
+type ReviewConnection {
+  """
+  Helpful metadata about the connection
+  """
+  pageInfo: PageInfo
+
+  """
+  List of reviews returned by the search
+  """
+  edges: [ReviewEdge]
+}
+
+type Query {
+  """
+  Fetch a simple list of products with an offset
+  """
+  topProducts(first: Int = 5): [Product]
+    @deprecated(reason: "Use products instead")
+
+  """
+  Fetch a paginated list of products based on a filter type.
+  """
+  products(first: Int = 5, after: Int = 0, type: ProductType): ProductConnection
+
+  """
+  The currently authenticated user root. All nodes off of this
+  root will be authenticated as the current user
+  """
+  me: User
+}`;

--- a/src/examples/react-example/index.tsx
+++ b/src/examples/react-example/index.tsx
@@ -65,7 +65,7 @@ function App() {
           },
           displayOptions: {
             showHeadersAndEnvVars: true,
-            theme,
+            theme: 'light',
           },
         }}
       />

--- a/src/examples/react-example/index.tsx
+++ b/src/examples/react-example/index.tsx
@@ -4,9 +4,11 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { ApolloExplorerReact } from '../../index';
 import { useState } from 'react';
+import { exampleSchema } from './exampleSchema';
 
 function App() {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [schema, setSchema] = useState(exampleSchema);
 
   return (
     <div>
@@ -21,6 +23,36 @@ function App() {
       <ApolloExplorerReact
         className="embedded-explorer"
         graphRef="acephei@current"
+        endpointUrl="https://acephei-gateway.herokuapp.com"
+        initialState={{
+          document: `query Example {
+	me {
+		id
+	}
+}`,
+          variables: {
+            test: 'abcxyz',
+          },
+          displayOptions: {
+            showHeadersAndEnvVars: true,
+            theme,
+          },
+        }}
+      />
+      Example with manual schema
+      <button
+        type="button"
+        onClick={() =>
+          setSchema(`type Query {
+            fieldA: String
+          }`)
+        }
+      >
+        Click me to change the schema
+      </button>
+      <ApolloExplorerReact
+        className="embedded-explorer"
+        schema={schema}
         endpointUrl="https://acephei-gateway.herokuapp.com"
         initialState={{
           document: `query Example {

--- a/src/examples/react-example/package.json
+++ b/src/examples/react-example/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "start": "parcel index.html",
-    "build": "parcel build index.html"
+    "start": "parcel index.html --no-cache",
+    "build": "parcel build index.html --no-cache"
   },
   "dependencies": {
   },

--- a/src/setupEmbedRelay.ts
+++ b/src/setupEmbedRelay.ts
@@ -4,7 +4,6 @@ import {
   EXPLORER_LISTENING_FOR_SCHEMA,
   EXPLORER_QUERY_MUTATION_REQUEST,
   EXPLORER_QUERY_MUTATION_RESPONSE,
-  SCHEMA_RESPONSE,
 } from './constants';
 
 export type HandleRequest = (
@@ -77,11 +76,17 @@ export function setupEmbedRelay({
   endpointUrl,
   handleRequest,
   embeddedExplorerIFrameElement,
+  updateSchemaInEmbed,
   schema,
 }: {
   endpointUrl: string;
   handleRequest: HandleRequest;
   embeddedExplorerIFrameElement: HTMLIFrameElement;
+  updateSchemaInEmbed: ({
+    schema,
+  }: {
+    schema: string | IntrospectionQuery | undefined;
+  }) => void;
   schema?: string | IntrospectionQuery | undefined;
 }) {
   // Callback definition
@@ -100,13 +105,7 @@ export function setupEmbedRelay({
       data.name === EXPLORER_LISTENING_FOR_SCHEMA &&
       !!schema
     ) {
-      embeddedExplorerIFrameElement.contentWindow?.postMessage(
-        {
-          name: SCHEMA_RESPONSE,
-          schema,
-        },
-        EMBEDDABLE_EXPLORER_URL
-      );
+      updateSchemaInEmbed({ schema });
     }
 
     // Check to see if the posted message indicates that the user is


### PR DESCRIPTION
~Previously, we were tearing down the existing embed and setting up a new instance of EmbeddedExplorer when params changed.~

~Now, we have a corresponding studio-ui PR that, when combined with this one, will accept pm's from the parent page when params change, and update them dynamically in the embed. No local state is lost!~

This PR is a necessary pre req to setting up the embed in Apollo Server, because the schema may dynamically change & we need to update it. The schema & param pm messages are different, because [we already listen for `SCHEMA_RESPONSE` in `useSchema` in studio-ui](https://github.com/mdg-private/studio-ui/blob/main/src/app/graph/hooks/useSchema.tsx#L134), and it is not a query param. 

[JIRA](https://apollographql.atlassian.net/browse/NEBULA-1161)