### PR TITLE
remove grey border on default iframes

### DIFF
--- a/.changeset/purple-forks-hang.md
+++ b/.changeset/purple-forks-hang.md
@@ -1,0 +1,5 @@
+---
+"@apollo/explorer": patch
+---
+
+remove grey border on default iframes

--- a/src/embeddedExplorer/EmbeddedExplorer.ts
+++ b/src/embeddedExplorer/EmbeddedExplorer.ts
@@ -95,7 +95,10 @@ export class EmbeddedExplorer {
     iframeElement.src = this.embeddedExplorerURL;
 
     iframeElement.id = IFRAME_DOM_ID(this.uniqueEmbedInstanceId);
-    iframeElement.setAttribute('style', 'height: 100%; width: 100%');
+    iframeElement.setAttribute(
+      'style',
+      'height: 100%; width: 100%; border: none;'
+    );
 
     element?.appendChild(iframeElement);
 


### PR DESCRIPTION
This grey border shows up on all embeds, I think we want to remove it by default for all embeds. 
![Screen Shot 2022-05-05 at 8 41 38 PM](https://user-images.githubusercontent.com/14367451/167063308-30596059-c70c-4c82-a626-da675ea55abf.png)

