### PR TITLE
Add postMessages and listeners for local storage token

### DIFF
--- a/src/embeddedExplorer/setupEmbedRelay.ts
+++ b/src/embeddedExplorer/setupEmbedRelay.ts
@@ -1,10 +1,13 @@
 import type { IntrospectionQuery } from 'graphql';
 import {
   EMBEDDABLE_EXPLORER_URL,
+  SET_AUTHENTICATED_TOKEN,
   EXPLORER_LISTENING_FOR_HANDSHAKE,
   EXPLORER_LISTENING_FOR_SCHEMA,
   EXPLORER_QUERY_MUTATION_REQUEST,
   HANDSHAKE_RESPONSE,
+  EXPLORER_LISTENING_FOR_TOKEN,
+  AUTHENTICATED_TOKEN_RESPONSE,
 } from '../helpers/constants';
 import {
   executeOperation,
@@ -41,6 +44,22 @@ export function setupEmbedRelay({
         message: {
           name: HANDSHAKE_RESPONSE,
           graphRef,
+        },
+        embeddedIFrameElement: embeddedExplorerIFrameElement,
+        embedUrl: EMBEDDABLE_EXPLORER_URL,
+      });
+    }
+
+    // When the embed authenticates, save the token in local storage
+    if (data.name === SET_AUTHENTICATED_TOKEN) {
+      window.localStorage.setItem(data.key, data.token);
+    }
+
+    if (data.name === EXPLORER_LISTENING_FOR_TOKEN) {
+      sendPostMessageToEmbed({
+        message: {
+          name: AUTHENTICATED_TOKEN_RESPONSE,
+          token: window.localStorage.getItem(data.key) ?? undefined,
         },
         embeddedIFrameElement: embeddedExplorerIFrameElement,
         embedUrl: EMBEDDABLE_EXPLORER_URL,

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -25,4 +25,7 @@ export const IFRAME_DOM_ID = (uniqueId: number) => `apollo-embed-${uniqueId}`;
 // Message types for authentication
 export const EXPLORER_LISTENING_FOR_HANDSHAKE = 'ExplorerListeningForHandshake';
 export const HANDSHAKE_RESPONSE = 'HandshakeResponse';
+export const SET_AUTHENTICATED_TOKEN = 'SetAuthenticatedToken';
+export const EXPLORER_LISTENING_FOR_TOKEN = 'ExplorerListeningForToken';
+export const AUTHENTICATED_TOKEN_RESPONSE = 'AuthenticatedTokenResponse';
 export const INTROSPECTION_QUERY_WITH_HEADERS = 'IntrospectionQueryWithHeaders';

--- a/src/helpers/postMessageRelayHelpers.ts
+++ b/src/helpers/postMessageRelayHelpers.ts
@@ -1,5 +1,6 @@
 import type { GraphQLError, IntrospectionQuery } from 'graphql';
 import {
+  AUTHENTICATED_TOKEN_RESPONSE,
   EMBEDDABLE_SANDBOX_URL,
   EXPLORER_QUERY_MUTATION_RESPONSE,
   HANDSHAKE_RESPONSE,
@@ -59,6 +60,10 @@ export type OutgoingEmbedMessage =
   | {
       name: typeof HANDSHAKE_RESPONSE;
       graphRef?: string;
+    }
+  | {
+      name: typeof AUTHENTICATED_TOKEN_RESPONSE;
+      token?: string;
     }
   | {
       name: typeof EXPLORER_QUERY_MUTATION_RESPONSE;


### PR DESCRIPTION
<!--
Please look through this checklist to see if there may be relevant actions to take before requesting reviewers:

https://apollographql.quip.com/six7ABVVjsB5#YIYABAGM2oX
-->

## Context
<img width="541" alt="Screen Shot 2022-05-09 at 1 30 12 AM" src="https://user-images.githubusercontent.com/16390269/167346242-31ed5e6c-4453-43ee-9f49-896e6d907e32.png">

## What changed
- After authorizing, the embed key is split into two parts, then stored in local storage

## How to test this PR
### Setup
- Switch to `william/explorer-everywhere/split-api-key` on studio-ui
- Switch to `william/split-api-key` on embeddable-explorer
- Change the `run` script in studio-ui to run on port 4000
```
exec node_modules/.bin/webpack serve \
  --config webpack.config.js \
  --mode development \
  --port 4000 \
  --env STUDIO_CONFIG_ENV=$TARGET_STACK
```
- Change these constants in `constants.ts` in embeddable-explorer and `embedded.ts` in studio-ui
```
export const EMBEDDABLE_EXPLORER_URL = 'https://embed.apollo.local:3000';
// 'https://explorer.embed.apollographql.com';
export const EMBEDDABLE_SANDBOX_URL = 'https://embed.apollo.local:3000/sandbox';
// 'https://sandbox.embed.apollographql.com/sandbox';
```
- Change the external link for dev in `runtime.ts` in studio-ui
```
[StudioConfigEnv.Dev]: {
    ...backends.staging,
    studioUrl: 'http://localhost:4000',
Add localhost:4000 to accepted origins in AuthenticateLoginPage.tsx in studio-ui
(event.origin === 'https://studio.apollographql.com' ||
          event.origin === 'https://studio-staging.apollographql.com' ||
          event.origin === 'http://localhost:4000')
```
- `npm run start:embedded` from studio-ui
- `./run staging` from studio-ui
- Open localDevelopmentExample in embeddedSandbox in the embeddable-explorer repo with the Go Live VS Code extension.