### PR TITLE
NEBULA-1163: Add optional config for inviteToken and accountId

### DIFF
--- a/.changeset/perfect-coats-cry.md
+++ b/.changeset/perfect-coats-cry.md
@@ -1,0 +1,5 @@
+---
+'@apollo/explorer': minor
+---
+
+Add optional config for inviteToken and accountId

--- a/src/embeddedExplorer/EmbeddedExplorer.ts
+++ b/src/embeddedExplorer/EmbeddedExplorer.ts
@@ -70,6 +70,8 @@ export class EmbeddedExplorer {
       updateSchemaInEmbed: this.updateSchemaInEmbed.bind(this),
       schema: 'schema' in this.options ? this.options.schema : undefined,
       graphRef: 'graphRef' in this.options ? this.options.graphRef : undefined,
+      inviteToken: 'inviteToken' in this.options ? this.options.inviteToken : undefined,
+      accountId: 'accountId' in this.options ? this.options.accountId ? undefined,
     });
   }
 

--- a/src/embeddedExplorer/EmbeddedExplorer.ts
+++ b/src/embeddedExplorer/EmbeddedExplorer.ts
@@ -29,8 +29,13 @@ export interface BaseEmbeddableExplorerOptions {
 
   // optional. defaults to `return fetch(url, fetchOptions)`
   handleRequest?: HandleRequest;
-  inviteToken?: string;
-  accountId?: string;
+  // If this object has values for `inviteToken` and `accountId`,
+  // any users who can see your embeddable Explorer are automatically
+  // invited to the account your graph is under with the role specified by the `inviteToken`.
+  autoInviteOptions?: {
+    accountId: string;
+    inviteToken: string;
+  };
 }
 
 interface EmbeddableExplorerOptionsWithSchema
@@ -72,10 +77,7 @@ export class EmbeddedExplorer {
       updateSchemaInEmbed: this.updateSchemaInEmbed.bind(this),
       schema: 'schema' in this.options ? this.options.schema : undefined,
       graphRef: 'graphRef' in this.options ? this.options.graphRef : undefined,
-      inviteToken:
-        'inviteToken' in this.options ? this.options.inviteToken : undefined,
-      accountId:
-        'accountId' in this.options ? this.options.accountId : undefined,
+      autoInviteOptions: this.options.autoInviteOptions,
     });
   }
 

--- a/src/embeddedExplorer/EmbeddedExplorer.ts
+++ b/src/embeddedExplorer/EmbeddedExplorer.ts
@@ -29,6 +29,8 @@ export interface BaseEmbeddableExplorerOptions {
 
   // optional. defaults to `return fetch(url, fetchOptions)`
   handleRequest?: HandleRequest;
+  inviteToken?: string;
+  accountId?: string;
 }
 
 interface EmbeddableExplorerOptionsWithSchema
@@ -70,8 +72,10 @@ export class EmbeddedExplorer {
       updateSchemaInEmbed: this.updateSchemaInEmbed.bind(this),
       schema: 'schema' in this.options ? this.options.schema : undefined,
       graphRef: 'graphRef' in this.options ? this.options.graphRef : undefined,
-      inviteToken: 'inviteToken' in this.options ? this.options.inviteToken : undefined,
-      accountId: 'accountId' in this.options ? this.options.accountId ? undefined,
+      inviteToken:
+        'inviteToken' in this.options ? this.options.inviteToken : undefined,
+      accountId:
+        'accountId' in this.options ? this.options.accountId : undefined,
     });
   }
 

--- a/src/embeddedExplorer/setupEmbedRelay.ts
+++ b/src/embeddedExplorer/setupEmbedRelay.ts
@@ -23,6 +23,8 @@ export function setupEmbedRelay({
   updateSchemaInEmbed,
   schema,
   graphRef,
+  inviteToken,
+  accountId,
 }: {
   endpointUrl: string;
   handleRequest: HandleRequest;
@@ -34,6 +36,8 @@ export function setupEmbedRelay({
   }) => void;
   schema?: string | IntrospectionQuery | undefined;
   graphRef?: string | undefined;
+  inviteToken?: string;
+  accountId?: string;
 }) {
   // Callback definition
   const onPostMessageReceived = (event: IncomingEmbedMessage) => {
@@ -44,6 +48,8 @@ export function setupEmbedRelay({
         message: {
           name: HANDSHAKE_RESPONSE,
           graphRef,
+          inviteToken,
+          accountId,
         },
         embeddedIFrameElement: embeddedExplorerIFrameElement,
         embedUrl: EMBEDDABLE_EXPLORER_URL,

--- a/src/embeddedExplorer/setupEmbedRelay.ts
+++ b/src/embeddedExplorer/setupEmbedRelay.ts
@@ -23,8 +23,7 @@ export function setupEmbedRelay({
   updateSchemaInEmbed,
   schema,
   graphRef,
-  inviteToken,
-  accountId,
+  autoInviteOptions,
 }: {
   endpointUrl: string;
   handleRequest: HandleRequest;
@@ -36,8 +35,10 @@ export function setupEmbedRelay({
   }) => void;
   schema?: string | IntrospectionQuery | undefined;
   graphRef?: string | undefined;
-  inviteToken?: string;
-  accountId?: string;
+  autoInviteOptions?: {
+    accountId: string;
+    inviteToken: string;
+  };
 }) {
   // Callback definition
   const onPostMessageReceived = (event: IncomingEmbedMessage) => {
@@ -48,8 +49,8 @@ export function setupEmbedRelay({
         message: {
           name: HANDSHAKE_RESPONSE,
           graphRef,
-          inviteToken,
-          accountId,
+          inviteToken: autoInviteOptions?.inviteToken,
+          accountId: autoInviteOptions?.accountId,
         },
         embeddedIFrameElement: embeddedExplorerIFrameElement,
         embedUrl: EMBEDDABLE_EXPLORER_URL,

--- a/src/helpers/postMessageRelayHelpers.ts
+++ b/src/helpers/postMessageRelayHelpers.ts
@@ -60,6 +60,8 @@ export type OutgoingEmbedMessage =
   | {
       name: typeof HANDSHAKE_RESPONSE;
       graphRef?: string;
+      inviteToken?: string;
+      accountId?: string;
     }
   | {
       name: typeof PARTIAL_AUTHENTICATION_TOKEN_RESPONSE;


### PR DESCRIPTION
We want producers of the embed to be able to configure settings to auto-invite users to the embedded graph's org when they authenticate.

## Testing
- Checkout to `william/auto-invite-org` on embeddable-explorer
- Checkout to `william/explorer-everywhere/auto-invite-org` on studio-ui
- Edit `embeddedExplorer/examples/localDevelopmentExample.html`, change graphRef to a private graph (that you aren't authorized on yet) and add `inviteToken` and `accountId`
```
new window.EmbeddedExplorer({
        target: '#embeddableExplorer',
        graphRef: 'graph@current',
        endpointUrl: 'https://acephei-gateway.herokuapp.com',
        inviteToken: ASK WILLIAM,
        accountId: 'will-test-org',
```
- `npm run build-explorer:umd` on embeddable-explorer
- `npm run start:embedded` on studio-ui
- Open localDevelopmentExample in the embeddable-explorer repo with the Go Live VS Code extension.
- Click `Authorize` and it should open up a link like
`http://localhost:3000/embed-authentication?accountId=will-test-org&embedSubdomain=explorer&graphRef=graph%40current&inviteToken=<ASKWILLIAM>&origin=http%3A%2F%2F127.0.0.1%3A5000`
- Ensure that the inviteToken and accountId match the configured parameters