### PR TITLE
point to correct index file for cjs/esm build

### DIFF
--- a/.changeset/wet-hornets-hope.md
+++ b/.changeset/wet-hornets-hope.md
@@ -1,0 +1,5 @@
+---
+"@apollo/explorer": patch
+---
+
+point to correct index file for cjs/esm build

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "tsdx watch",
     "build": "npm run build-explorer:cjs-esm",
-    "build-explorer:cjs-esm": "tsdx build --format cjs,esm --name embeddable-explorer",
+    "build-explorer:cjs-esm": "tsdx build --format cjs,esm --entry src/embeddedExplorer/index.ts --name embeddable-explorer",
     "build-explorer:umd": "tsdx build --format umd --entry src/embeddedExplorer/index-umd.ts --name embeddable-explorer",
     "build-sandbox:umd": "tsdx build --format umd --entry src/embeddedSandbox/index-umd.ts --name embeddable-sandbox",
     "test": "tsdx test --passWithNoTests",


### PR DESCRIPTION
I moved these files around in a different PR, but forgot to repoint the cjs / esm build command!