### PR TITLE
add config option: `includeCookies`

### DIFF
--- a/.changeset/selfish-trains-approve.md
+++ b/.changeset/selfish-trains-approve.md
@@ -1,0 +1,5 @@
+---
+"@apollo/explorer": minor
+---
+
+add config option: `includeCookies`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ me {
 - [Embedding a registered public graph](./src/embeddableExplorer/examples/graphRef.html)
 - [Usage by directly passing in schema](./src/embeddableExplorer/examples/manualSchema.html)
 
-## Developing
+## Developing Embedded Explorer
 
 run `npm run build-explorer:umd` to build umd files where EmbeddedExplorer is exposed on window.
 
@@ -89,8 +89,12 @@ Open `examples/embeddedExplorer/localDevelopmentExample.html` to test your chang
 Install the `Live Server` extension on VSCode, then go to `localDevelopmentExample.html` and click 'Go Live'
 <img width="279" alt="Screen Shot 2022-04-27 at 4 34 53 PM" src="https://user-images.githubusercontent.com/16390269/165626464-8252abcd-2577-4d97-90a8-f487da807a64.png">
 
+### Developing embedded Explorer with the React example
 
 run `npm run build-explorer:cjs-esm` to build cjs & esm files where ApolloExplorer & ApolloExplorerReact are named exports.
+
+We have a React example app that uses our ApolloExplorerReact component to render the embedded Explorer located in src/embeddedExplorer/examples/react-example. To run this example, `npm run build` and `npm run start` in `react-example`. Make sure you delete the .parcel-cache folder before you rebuild for new changes. (TODO remove parcel caching)
+
 
 ## Developing Embedded Sandbox
 

--- a/src/embeddedExplorer/EmbeddedExplorer.ts
+++ b/src/embeddedExplorer/EmbeddedExplorer.ts
@@ -4,6 +4,7 @@ import {
   IFRAME_DOM_ID,
   SCHEMA_RESPONSE,
 } from '../helpers/constants';
+import { defaultHandleRequest } from '../helpers/defaultHandleRequest';
 import {
   HandleRequest,
   sendPostMessageToEmbed,
@@ -29,6 +30,8 @@ export interface BaseEmbeddableExplorerOptions {
 
   // optional. defaults to `return fetch(url, fetchOptions)`
   handleRequest?: HandleRequest;
+  // defaults to false. If you pass `handleRequest` that will override this.
+  includeCookies?: boolean;
   // If this object has values for `inviteToken` and `accountId`,
   // any users who can see your embeddable Explorer are automatically
   // invited to the account your graph is under with the role specified by the `inviteToken`.
@@ -66,7 +69,9 @@ export class EmbeddedExplorer {
   constructor(options: EmbeddableExplorerOptions) {
     this.options = options;
     this.validateOptions();
-    this.handleRequest = this.options.handleRequest ?? fetch;
+    this.handleRequest =
+      this.options.handleRequest ??
+      defaultHandleRequest({ includeCookies: !!this.options.includeCookies });
     this.uniqueEmbedInstanceId = idCounter++;
     this.embeddedExplorerURL = this.getEmbeddedExplorerURL();
     this.embeddedExplorerIFrameElement = this.injectEmbed();

--- a/src/embeddedExplorer/examples/react-example/package.json
+++ b/src/embeddedExplorer/examples/react-example/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
   },
   "alias": {
-    "react": "../../../node_modules/react",
-    "react-dom": "../../../node_modules/react-dom",
+    "react": "../../../../node_modules/react",
+    "react-dom": "../../../../node_modules/react-dom",
     "scheduler/tracing": "../../../node_modules/scheduler/tracing-profiling"
   },
   "devDependencies": {

--- a/src/embeddedExplorer/react/index.tsx
+++ b/src/embeddedExplorer/react/index.tsx
@@ -30,6 +30,20 @@ export function ApolloExplorerReact(
   const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>();
 
   const currentEmbedRef = useRef<EmbeddedExplorer>();
+  // we need to default to empty objects for the objects type props
+  // that show up in the useDeepCompareEffect below, because useDeepCompareEffect
+  // will throw if all of its deps are primitives (undefined instead of objects)
+  const {
+    endpointUrl,
+    handleRequest,
+    initialState = {},
+    persistExplorerState,
+    graphRef,
+    autoInviteOptions = {},
+    includeCookies,
+    className,
+    schema,
+  } = props;
 
   useDeepCompareEffect(
     () => {
@@ -45,25 +59,27 @@ export function ApolloExplorerReact(
     },
     // we purposely exclude schema here
     // when the schema changes we don't want to tear down and render a new embed,
-    // we just want to pm the new schema to the embed in the above useEffect
+    // we just want to pm the new schema to the embed in the below useEffect
     [
-      props.endpointUrl,
-      props.handleRequest,
-      props.initialState,
-      props.persistExplorerState,
-      props.graphRef,
+      endpointUrl,
+      handleRequest,
+      initialState,
+      persistExplorerState,
+      graphRef,
+      autoInviteOptions,
+      includeCookies,
+      className,
       wrapperElement,
     ]
   );
 
   useEffect(() => {
-    if (props.schema)
-      currentEmbedRef.current?.updateSchemaInEmbed({ schema: props.schema });
-  }, [props.schema, currentEmbedRef.current]);
+    if (schema) currentEmbedRef.current?.updateSchemaInEmbed({ schema });
+  }, [schema, currentEmbedRef.current]);
 
   return (
     <div
-      className={props.className}
+      className={className}
       ref={(element) => {
         setWrapperElement(element);
       }}

--- a/src/embeddedSandbox/EmbeddedSandbox.ts
+++ b/src/embeddedSandbox/EmbeddedSandbox.ts
@@ -4,6 +4,7 @@ import {
   IFRAME_DOM_ID,
   SCHEMA_RESPONSE,
 } from '../helpers/constants';
+import { defaultHandleRequest } from '../helpers/defaultHandleRequest';
 import {
   HandleRequest,
   sendPostMessageToEmbed,
@@ -16,6 +17,8 @@ export interface EmbeddableSandboxOptions {
 
   // optional. defaults to `return fetch(url, fetchOptions)`
   handleRequest?: HandleRequest;
+  // defaults to false. If you pass `handleRequest` that will override this.
+  includeCookies?: boolean;
 }
 
 let idCounter = 0;
@@ -29,7 +32,9 @@ export class EmbeddedSandbox {
   constructor(options: EmbeddableSandboxOptions) {
     this.options = options;
     this.validateOptions();
-    this.handleRequest = this.options.handleRequest ?? fetch;
+    this.handleRequest =
+      this.options.handleRequest ??
+      defaultHandleRequest({ includeCookies: !!this.options.includeCookies });
     this.uniqueEmbedInstanceId = idCounter++;
     this.embeddedSandboxIFrameElement = this.injectEmbed();
     this.disposable = setupSandboxEmbedRelay({

--- a/src/helpers/defaultHandleRequest.ts
+++ b/src/helpers/defaultHandleRequest.ts
@@ -1,0 +1,14 @@
+import type { HandleRequest } from './postMessageRelayHelpers';
+
+export const defaultHandleRequest = ({
+  includeCookies,
+}: {
+  includeCookies: boolean;
+}): HandleRequest => {
+  const handleRequestWithCookiePref: HandleRequest = (endpointUrl, options) =>
+    fetch(endpointUrl, {
+      ...options,
+      ...(includeCookies ? { credentials: 'include' } : {}),
+    });
+  return handleRequestWithCookiePref;
+};


### PR DESCRIPTION
Pass through `includeCookies` to default fetch handler for both embedded sandbox & explorer