### PR TITLE
🐛 fix but where useDeepCompareEffect expects objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ me {
 - [Embedding a registered public graph](./src/embeddableExplorer/examples/graphRef.html)
 - [Usage by directly passing in schema](./src/embeddableExplorer/examples/manualSchema.html)
 
-## Developing
+## Developing Embedded Explorer
 
 run `npm run build-explorer:umd` to build umd files where EmbeddedExplorer is exposed on window.
 
@@ -89,8 +89,12 @@ Open `examples/embeddedExplorer/localDevelopmentExample.html` to test your chang
 Install the `Live Server` extension on VSCode, then go to `localDevelopmentExample.html` and click 'Go Live'
 <img width="279" alt="Screen Shot 2022-04-27 at 4 34 53 PM" src="https://user-images.githubusercontent.com/16390269/165626464-8252abcd-2577-4d97-90a8-f487da807a64.png">
 
+### Developing embedded Explorer with the React example
 
 run `npm run build-explorer:cjs-esm` to build cjs & esm files where ApolloExplorer & ApolloExplorerReact are named exports.
+
+We have a React example app that uses our ApolloExplorerReact component to render the embedded Explorer located in src/embeddedExplorer/examples/react-example. To run this example, `npm run build` and `npm run start` in `react-example`. Make sure you delete the .parcel-cache folder before you rebuild for new changes. (TODO remove parcel caching)
+
 
 ## Developing Embedded Sandbox
 

--- a/src/embeddedExplorer/examples/react-example/package.json
+++ b/src/embeddedExplorer/examples/react-example/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
   },
   "alias": {
-    "react": "../../../node_modules/react",
-    "react-dom": "../../../node_modules/react-dom",
+    "react": "../../../../node_modules/react",
+    "react-dom": "../../../../node_modules/react-dom",
     "scheduler/tracing": "../../../node_modules/scheduler/tracing-profiling"
   },
   "devDependencies": {

--- a/src/embeddedExplorer/react/index.tsx
+++ b/src/embeddedExplorer/react/index.tsx
@@ -30,6 +30,17 @@ export function ApolloExplorerReact(
   const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>();
 
   const currentEmbedRef = useRef<EmbeddedExplorer>();
+  const {
+    endpointUrl,
+    handleRequest,
+    initialState = {},
+    persistExplorerState,
+    graphRef,
+    autoInviteOptions = {},
+    includeCookies,
+    className,
+    schema,
+  } = props;
 
   useDeepCompareEffect(
     () => {
@@ -45,25 +56,27 @@ export function ApolloExplorerReact(
     },
     // we purposely exclude schema here
     // when the schema changes we don't want to tear down and render a new embed,
-    // we just want to pm the new schema to the embed in the above useEffect
+    // we just want to pm the new schema to the embed in the below useEffect
     [
-      props.endpointUrl,
-      props.handleRequest,
-      props.initialState,
-      props.persistExplorerState,
-      props.graphRef,
+      endpointUrl,
+      handleRequest,
+      initialState,
+      persistExplorerState,
+      graphRef,
+      autoInviteOptions,
+      includeCookies,
+      className,
       wrapperElement,
     ]
   );
 
   useEffect(() => {
-    if (props.schema)
-      currentEmbedRef.current?.updateSchemaInEmbed({ schema: props.schema });
-  }, [props.schema, currentEmbedRef.current]);
+    if (schema) currentEmbedRef.current?.updateSchemaInEmbed({ schema });
+  }, [schema, currentEmbedRef.current]);
 
   return (
     <div
-      className={props.className}
+      className={className}
       ref={(element) => {
         setWrapperElement(element);
       }}

--- a/src/embeddedExplorer/react/index.tsx
+++ b/src/embeddedExplorer/react/index.tsx
@@ -30,6 +30,9 @@ export function ApolloExplorerReact(
   const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>();
 
   const currentEmbedRef = useRef<EmbeddedExplorer>();
+  // we need to default to empty objects for the objects type props
+  // that show up in the useDeepCompareEffect below, because useDeepCompareEffect
+  // will throw if all of its deps are primitives (undefined instead of objects)
   const {
     endpointUrl,
     handleRequest,


### PR DESCRIPTION
We were seeing the error `useDeepCompareEffect should not be used with dependencies that are all primitive values.` in the React embedded Explorer. This is because the objects in the `useDeepCompareEffect` are optional - so if they are all undefined, it's all primitives in there.

This PR defaults to an empty object for the object types, so there are always objects in the deep compare effect 