### PR TITLE
NEBULA-1288: Add logout messages to parent

### DIFF
--- a/.changeset/tiny-camels-behave.md
+++ b/.changeset/tiny-camels-behave.md
@@ -1,0 +1,5 @@
+---
+'@apollo/explorer': minor
+---
+
+Add logout messages to parent

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -27,8 +27,7 @@ export const EXPLORER_LISTENING_FOR_HANDSHAKE = 'ExplorerListeningForHandshake';
 export const HANDSHAKE_RESPONSE = 'HandshakeResponse';
 export const SET_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT =
   'SetPartialAuthenticationTokenForParent';
-export const REMOVE_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT =
-  'RemovePartialAuthenticationTokenForParent';
+export const TRIGGER_LOGOUT_IN_PARENT = 'TriggerLogoutInParent';
 export const EXPLORER_LISTENING_FOR_PARTIAL_TOKEN =
   'ExplorerListeningForPartialToken';
 export const PARTIAL_AUTHENTICATION_TOKEN_RESPONSE =

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -34,4 +34,4 @@ export const EXPLORER_LISTENING_FOR_PARTIAL_TOKEN =
 export const PARTIAL_AUTHENTICATION_TOKEN_RESPONSE =
   'PartialAuthenticationTokenResponse';
 export const INTROSPECTION_QUERY_WITH_HEADERS = 'IntrospectionQueryWithHeaders';
-export const PARENT_LOGOUT_RESPONSE = 'ParentLogoutResponse';
+export const PARENT_LOGOUT_SUCCESS = 'ParentLogoutSuccess';

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -27,8 +27,11 @@ export const EXPLORER_LISTENING_FOR_HANDSHAKE = 'ExplorerListeningForHandshake';
 export const HANDSHAKE_RESPONSE = 'HandshakeResponse';
 export const SET_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT =
   'SetPartialAuthenticationTokenForParent';
+export const REMOVE_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT =
+  'RemovePartialAuthenticationTokenForParent';
 export const EXPLORER_LISTENING_FOR_PARTIAL_TOKEN =
   'ExplorerListeningForPartialToken';
 export const PARTIAL_AUTHENTICATION_TOKEN_RESPONSE =
   'PartialAuthenticationTokenResponse';
 export const INTROSPECTION_QUERY_WITH_HEADERS = 'IntrospectionQueryWithHeaders';
+export const PARENT_LOGOUT_RESPONSE = 'ParentLogoutResponse';

--- a/src/helpers/postMessageRelayHelpers.ts
+++ b/src/helpers/postMessageRelayHelpers.ts
@@ -8,7 +8,7 @@ import {
   SCHEMA_RESPONSE,
   SET_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT,
   EXPLORER_LISTENING_FOR_PARTIAL_TOKEN,
-  PARENT_LOGOUT_RESPONSE,
+  PARENT_LOGOUT_SUCCESS,
   REMOVE_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT,
 } from './constants';
 import type { JSONValue } from '../types';
@@ -83,7 +83,7 @@ export type OutgoingEmbedMessage =
       };
     }
   | {
-      name: typeof PARENT_LOGOUT_RESPONSE;
+      name: typeof PARENT_LOGOUT_SUCCESS;
     };
 
 // TODO(Maya) uncomment and switch to MessageEvent as a generic when tsdx supports Typescript V4.
@@ -299,7 +299,7 @@ export const handleAuthenticationPostMessage = ({
       JSON.stringify(partialEmbedApiKeys)
     );
     sendPostMessageToEmbed({
-      message: { name: PARENT_LOGOUT_RESPONSE },
+      message: { name: PARENT_LOGOUT_SUCCESS },
       embeddedIFrameElement,
       embedUrl,
     });

--- a/src/helpers/postMessageRelayHelpers.ts
+++ b/src/helpers/postMessageRelayHelpers.ts
@@ -9,7 +9,7 @@ import {
   SET_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT,
   EXPLORER_LISTENING_FOR_PARTIAL_TOKEN,
   PARENT_LOGOUT_SUCCESS,
-  REMOVE_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT,
+  TRIGGER_LOGOUT_IN_PARENT,
 } from './constants';
 import type { JSONValue } from '../types';
 
@@ -110,7 +110,7 @@ export type IncomingEmbedMessage = MessageEvent;
 //     partialToken: string;
 //   }>
 // | MessageEvent<{
-//     name: typeof REMOVE_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT;
+//     name: typeof TRIGGER_LOGOUT_IN_PARENT;
 //     localStorageKey: string;
 //   }>
 // | MessageEvent<{
@@ -286,7 +286,7 @@ export const handleAuthenticationPostMessage = ({
   }
 
   // When the embed logs out, remove the partial token in local storage
-  if (data.name === REMOVE_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT) {
+  if (data.name === TRIGGER_LOGOUT_IN_PARENT) {
     const partialEmbedApiKeysString = window.localStorage.getItem(
       'apolloStudioEmbeddedExplorerEncodedApiKey'
     );


### PR DESCRIPTION
[JIRA](https://apollographql.atlassian.net/browse/NEBULA-1288)

We want to send a PM to the parent when a user clicks 'log out' to clear the parent local storage and then send a PM back that we listen for in the useEmbedUserToken , and clear the embedUserToken & local storage.