### PR TITLE
respect classes that folks applied to their embed elements

### DIFF
--- a/.changeset/brave-snakes-rhyme.md
+++ b/.changeset/brave-snakes-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@apollo/explorer": patch
+---
+
+respect classes that folks applied to their embed elements

--- a/src/embeddedExplorer/EmbeddedExplorer.ts
+++ b/src/embeddedExplorer/EmbeddedExplorer.ts
@@ -113,8 +113,20 @@ export class EmbeddedExplorer {
       'height: 100%; width: 100%; border: none;'
     );
 
-    Object.assign(element?.style, { height: element?.style.height || '100%' });
-    Object.assign(element?.style, { width: element?.style.width || '100%' });
+    // if there is no className applied to the element, add height & width via the `style` attribute.
+    // the `style` attribute overrides any className, so we want to default to the users className always
+    if (element && !element.className) {
+      Object.assign(element, {
+        style: element.style ?? {},
+      });
+      Object.assign(element.style, {
+        height: element.style.height.length ? element.style.height : '100%',
+      });
+      Object.assign(element.style, {
+        width: element.style.width.length ? element.style.width : '100%',
+      });
+      console.log('element', element.style);
+    }
 
     element?.appendChild(iframeElement);
 

--- a/src/embeddedSandbox/EmbeddedSandbox.ts
+++ b/src/embeddedSandbox/EmbeddedSandbox.ts
@@ -53,7 +53,7 @@ export class EmbeddedSandbox {
   }
 
   injectEmbed() {
-    let element;
+    let element: HTMLElement | null;
     const { target } = this.options;
 
     if (typeof target === 'string') {
@@ -73,6 +73,21 @@ export class EmbeddedSandbox {
       'style',
       'height: 100%; width: 100%; border: none;'
     );
+
+    // if there is no className applied to the element, add height & width via the `style` attribute.
+    // the `style` attribute overrides any className, so we want to default to the users className always
+    if (element && !element.className) {
+      Object.assign(element, {
+        style: element.style ?? {},
+      });
+      Object.assign(element.style, {
+        height: element.style.height.length ? element.style.height : '100%',
+      });
+      Object.assign(element.style, {
+        width: element.style.width.length ? element.style.width : '100%',
+      });
+      console.log('element', element.style);
+    }
 
     element?.appendChild(iframeElement);
 


### PR DESCRIPTION
Previously I had this logic

```
   Object.assign(element?.style, { height: element?.style.height || '100%' });
    Object.assign(element?.style, { width: element?.style.width || '100%' });
```

to default to full screen iframe for the embedded Explorer. This only checked if `style` attributes were set by the user. Folks may set `className`, and this was overriding their classes, so lets not do anything if they have already set className either.