### PR TITLE
🐛 🩹 always send `shouldShowGlobalHeader` as true from this repo

### DIFF
--- a/.changeset/purple-keys-sniff.md
+++ b/.changeset/purple-keys-sniff.md
@@ -1,0 +1,5 @@
+---
+"@apollo/explorer": patch
+---
+
+🐛 🩹 always send `shouldShowGlobalHeader` as true from this repo

--- a/src/embeddedExplorer/EmbeddedExplorer.ts
+++ b/src/embeddedExplorer/EmbeddedExplorer.ts
@@ -176,6 +176,7 @@ export class EmbeddedExplorer {
       showHeadersAndEnvVars: displayOptions?.showHeadersAndEnvVars !== false,
       theme: displayOptions?.theme ?? 'dark',
       shouldShowGlobalHeader: true,
+      parentSupportsSubscriptions: false,
     };
 
     const queryString = Object.entries(queryParams)

--- a/src/embeddedExplorer/EmbeddedExplorer.ts
+++ b/src/embeddedExplorer/EmbeddedExplorer.ts
@@ -175,6 +175,7 @@ export class EmbeddedExplorer {
       docsPanelState: displayOptions?.docsPanelState ?? 'open',
       showHeadersAndEnvVars: displayOptions?.showHeadersAndEnvVars !== false,
       theme: displayOptions?.theme ?? 'dark',
+      shouldShowGlobalHeader: true,
     };
 
     const queryString = Object.entries(queryParams)


### PR DESCRIPTION
apollo dev tools v 4.0.0 doesn't send this query param, so we need it to default to false on the studio end so the folks on v 4.0.0 don't see the header. 

<img width="661" alt="image (21)" src="https://user-images.githubusercontent.com/14367451/170158518-57b590fc-3d03-4f27-9cd5-e846eb0db5b3.png">
