### PR TITLE
code sandbox deploy preview 🐛 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
     "trailingComma": "es5",
     "endOfLine": "auto"
   },
-  "module": "dist/embeddable-explorer.esm.js",
+  "module": "dist/explorer.esm.js",
   "size-limit": [
     {
-      "path": "dist/embeddable-explorer.cjs.production.min.js",
+      "path": "dist/explorer.cjs.production.min.js",
       "limit": "10 KB"
     },
     {
-      "path": "dist/embeddable-explorer.esm.js",
+      "path": "dist/explorer.esm.js",
       "limit": "10 KB"
     }
   ],


### PR DESCRIPTION
I am confused because according to[ this comment](https://github.com/codesandbox/codesandbox-ci-ui/issues/40#issuecomment-1141960749) and what we have seen in playing around debugging npm publishes before, the built cjs / esm files are built prefixed with `explorer` when you pull them down from npm, but when built locally they are prefixed with `embeddable-explorer`?

Test by clicking on the code sandbox deploy preview below and see that it all works!