### PR TITLE
fix vanilla export to not need react deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "@apollo/explorer",
-  "version": "0.3.2",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/explorer",
-      "version": "0.3.2",
+      "version": "0.5.2",
       "license": "MIT",
-      "dependencies": {
-        "use-deep-compare-effect": "^1.8.1"
-      },
       "devDependencies": {
         "@changesets/changelog-github": "0.4.4",
         "@changesets/cli": "2.22.0",
@@ -34,7 +31,8 @@
         "size-limit": "5.0.5",
         "tsdx": "0.14.1",
         "tslib": "2.3.1",
-        "typescript": "3.9.10"
+        "typescript": "3.9.10",
+        "use-deep-compare-effect": "^1.8.1"
       },
       "engines": {
         "node": ">=12.0",
@@ -42,13 +40,17 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "use-deep-compare-effect": "^1.8.1"
       },
       "peerDependenciesMeta": {
         "react": {
           "optional": true
         },
         "react-dom": {
+          "optional": true
+        },
+        "use-deep-compare-effect": {
           "optional": true
         }
       }
@@ -1552,6 +1554,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.17.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -5266,6 +5269,7 @@
     },
     "node_modules/dequal": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8061,6 +8065,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -8510,6 +8515,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -10588,6 +10594,7 @@
     },
     "node_modules/react": {
       "version": "18.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -10752,6 +10759,7 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/regenerator-transform": {
@@ -16629,6 +16637,7 @@
     },
     "node_modules/use-deep-compare-effect": {
       "version": "1.8.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -18273,6 +18282,7 @@
     },
     "@babel/runtime": {
       "version": "7.17.9",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -20901,7 +20911,8 @@
       "dev": true
     },
     "dequal": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "dev": true
     },
     "des.js": {
       "version": "1.0.1",
@@ -22758,7 +22769,8 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -23073,6 +23085,7 @@
     },
     "loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -24397,6 +24410,7 @@
     },
     "react": {
       "version": "18.1.0",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -24514,7 +24528,8 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9"
+      "version": "0.13.9",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -28811,6 +28826,7 @@
     },
     "use-deep-compare-effect": {
       "version": "1.8.1",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "dequal": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "prettier": "2.6.2",
     "react": "18.1.0",
     "react-dom": "18.1.0",
+    "use-deep-compare-effect": "^1.8.1",
     "size-limit": "5.0.5",
     "tsdx": "0.14.1",
     "tslib": "2.3.1",
@@ -84,7 +85,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "use-deep-compare-effect": "^1.8.1"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -92,9 +94,11 @@
     },
     "react-dom": {
       "optional": true
+    },
+    "use-deep-compare-effect": {
+      "optional": true
     }
   },
   "dependencies": {
-    "use-deep-compare-effect": "^1.8.1"
   }
 }


### PR DESCRIPTION
This is only required for the react export. 

I am trying to set up a code sandbox using the vanilla only export and seeing 
<img width="541" alt="Screen Shot 2022-06-03 at 5 49 09 PM" src="https://user-images.githubusercontent.com/14367451/171958663-cb8c2b7d-e140-40e5-9733-56f06567db15.png">

Which is a little concerning. I thought maybe it was because this is required, but now I realize this is in the built file ...