### PR TITLE
Split React export into its own file

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,7 @@
 {
   "sandboxes": ["npm-embeddable-explorer-zotwkv"],
-  "buildCommand": "build"
+  "buildCommand": "build",
+  "publishDirectory": {
+    "@apollo/explorer": "dist"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This repo hosts the source for Apollo Studio's Embeddable Explorer & the Embedda
 
 ### Using the [@apollo/explorer npm package](https://www.npmjs.com/package/@apollo/explorer)
 
-You can download the @apollo/explorer npm package with `npm install @apollo/explorer`. Then, you can import the ApolloExplorer class or ApolloExplorerReact component like so:
+You can download the @apollo/explorer npm package with `npm install @apollo/explorer`. Then, you can import the ApolloExplorer class or ApolloExplorer React component like so:
 
 ```
-import { ApolloExplorer, ApolloExplorerReact } from '@apollo/explorer';
+import { ApolloExplorer } from '@apollo/explorer';
+import { ApolloExplorer } from '@apollo/explorer/react';
 ```
 
 When you call the EmbeddedExplorer constructor with a `target` of an html div you have in your app, the Explorer will show up in an iframe in that element. Check out all the [configuration options](https://www.apollographql.com/docs/studio/explorer/embed-explorer/#options) for your graph.
@@ -17,12 +18,12 @@ When you call the EmbeddedExplorer constructor with a `target` of an html div yo
 #### React
 
 ```
-import { ApolloExplorerReact } from '@apollo/explorer';
+import { ApolloExplorer } from '@apollo/explorer/react';
 
 function App() {
 
   return (
-    <ApolloExplorerReact
+    <ApolloExplorer
       graphRef='acephei@current',
       endpointUrl='https://acephei-gateway.herokuapp.com',
       initialState={{
@@ -91,9 +92,9 @@ Install the `Live Server` extension on VSCode, then go to `localDevelopmentExamp
 
 ### Developing embedded Explorer with the React example
 
-run `npm run build-explorer:cjs-esm` to build cjs & esm files where ApolloExplorer & ApolloExplorerReact are named exports.
+run `npm run build-explorer:cjs-esm` to build cjs & esm files where ApolloExplorer & ApolloExplorer React are named exports.
 
-We have a React example app that uses our ApolloExplorerReact component to render the embedded Explorer located in src/embeddedExplorer/examples/react-example. To run this example, `npm run build` and `npm run start` in `react-example`. Make sure you delete the .parcel-cache folder before you rebuild for new changes. (TODO remove parcel caching)
+We have a React example app that uses our ApolloExplorer React component to render the embedded Explorer located in src/embeddedExplorer/examples/react-example. To run this example, `npm run build` and `npm run start` in `react-example`. Make sure you delete the .parcel-cache folder before you rebuild for new changes. (TODO remove parcel caching)
 
 
 ## Developing Embedded Sandbox

--- a/buildHelpers/createRollupConfig.js
+++ b/buildHelpers/createRollupConfig.js
@@ -98,6 +98,13 @@ function createCJS_ESMRollupConfig(options) {
             ? '[name].production.min.js'
             : '[name].development.js',
       }),
+      sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
+        // will replace relative paths with absolute paths
+        return relativeSourcePath
+          .replace('src/', '')
+          .replace('node_modules/', 'external/')
+          .replace('../../external', '../external');
+      },
     },
     external: ['use-deep-compare-effect', 'react'],
     plugins: [

--- a/buildHelpers/createRollupConfig.js
+++ b/buildHelpers/createRollupConfig.js
@@ -68,7 +68,13 @@ function createUMDRollupConfig(options) {
 
 function createCJS_ESMRollupConfig(options) {
   return {
-    input: 'src/index.ts',
+    input: {
+      // We have two entry files - the vanilla js class export (index.js) and
+      // the react export which is exported from its own file.
+      // This allows folks to skip bundling with react if they just want to use the vanilla js class
+      index: 'src/index.ts',
+      'react/index': 'src/react/index.ts',
+    },
     output: {
       format: options.format,
       freeze: false,

--- a/buildHelpers/prepareDist.js
+++ b/buildHelpers/prepareDist.js
@@ -1,0 +1,55 @@
+const fs = require('fs-extra');
+
+// write a package.json to the react folder
+// for folks importing from @apollo/explorer/react
+const contents =
+  JSON.stringify(
+    {
+      name: '@apollo/explorer/react',
+      type: 'module',
+      main: `index.cjs`,
+      module: 'index.mjs',
+      types: 'index.d.ts',
+      sideEffects: false,
+    },
+    null,
+    2
+  ) + '\n';
+fs.outputFile('dist/react/package.json', contents);
+
+// We copy the package.json to the dist folder, since when we publish we
+// publish from inside the dist folder (see publish-changeset npm script).
+const packageJson = require('../package.json');
+packageJson.type = 'module';
+
+// Remove package.json items that we don't need to publish
+delete packageJson.scripts;
+delete packageJson.bundlesize;
+delete packageJson.engines;
+
+// The root package.json points to the CJS/ESM source in "dist", to support
+// on-going package development (e.g. running tests, supporting npm link, etc.).
+// When publishing from "dist" however, we need to update the package.json
+// to point to the files within the same directory.
+const distPackageJson =
+  JSON.stringify(
+    packageJson,
+    (_key, value) => {
+      if (typeof value === 'string' && value.startsWith('dist/')) {
+        const parts = value.split('/');
+        parts.splice(0, 1); // remove dist
+        return './' + parts.join('/');
+      }
+      return value;
+    },
+    2
+  ) + '\n';
+
+// Save the modified package.json to "dist"
+fs.writeFileSync(`./dist/package.json`, distPackageJson);
+
+// Copy supporting files into "dist"
+const srcDir = `${__dirname}/..`;
+const destDir = `${srcDir}/dist`;
+fs.copyFileSync(`${srcDir}/README.md`, `${destDir}/README.md`);
+fs.copyFileSync(`${srcDir}/LICENSE`, `${destDir}/LICENSE`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,6 @@
       "name": "@apollo/explorer",
       "version": "0.5.2",
       "license": "MIT",
-      "dependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "use-deep-compare-effect": "^1.8.1"
-      },
       "devDependencies": {
         "@babel/core": "^7.18.5",
         "@changesets/changelog-github": "0.4.4",
@@ -20,6 +15,7 @@
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-typescript": "^8.3.2",
         "@size-limit/preset-small-lib": "5.0.5",
+        "@types/fs-extra": "^9.0.13",
         "@types/react": "18.0.8",
         "@types/react-dom": "18.0.3",
         "@typescript-eslint/eslint-plugin": "5.21.0",
@@ -31,6 +27,7 @@
         "eslint-plugin-prettier": "^3.3.1",
         "eslint-plugin-react": "^7.29.4",
         "eslint-plugin-react-hooks": "4.5.0",
+        "fs-extra": "^10.1.0",
         "graphql": "15.8.0",
         "husky": "7.0.4",
         "prettier": "2.6.2",
@@ -45,6 +42,22 @@
       "engines": {
         "node": ">=12.0",
         "npm": ">=7.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "use-deep-compare-effect": "^1.8.1"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "use-deep-compare-effect": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -359,6 +372,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.17.9",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -1427,6 +1441,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/is-ci": {
@@ -3386,6 +3409,8 @@
     "node_modules/dequal": {
       "version": "2.0.2",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4563,6 +4588,41 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/fs-write-stream-atomic": {
       "version": "1.0.10",
       "dev": true,
@@ -5405,6 +5465,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5601,6 +5662,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7285,6 +7347,7 @@
     },
     "node_modules/react": {
       "version": "18.1.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -7414,6 +7477,7 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/regex-not": {
@@ -8926,6 +8990,8 @@
     "node_modules/use-deep-compare-effect": {
       "version": "1.8.1",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "dequal": "^2.0.2"
@@ -9804,6 +9870,7 @@
     },
     "@babel/runtime": {
       "version": "7.17.9",
+      "devOptional": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -10603,6 +10670,15 @@
     "@trysound/sax": {
       "version": "0.2.0",
       "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/is-ci": {
       "version": "3.0.0",
@@ -11956,7 +12032,9 @@
       }
     },
     "dequal": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "optional": true,
+      "peer": true
     },
     "des.js": {
       "version": "1.0.1",
@@ -12767,6 +12845,35 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "dev": true,
@@ -13276,7 +13383,8 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "devOptional": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -13413,6 +13521,7 @@
     },
     "loose-envify": {
       "version": "1.4.0",
+      "devOptional": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -14465,6 +14574,7 @@
     },
     "react": {
       "version": "18.1.0",
+      "devOptional": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -14558,7 +14668,8 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9"
+      "version": "0.13.9",
+      "devOptional": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -15590,6 +15701,8 @@
     },
     "use-deep-compare-effect": {
       "version": "1.8.1",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "dequal": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "npm run build-explorer:cjs-esm",
-    "build-explorer:cjs-esm": "rm -rf dist && rollup -c buildHelpers/rollup.explorer.cjs-esm.config.js && cp src/index.cjs dist/index.cjs && cp src/react/index.cjs dist/react/index.cjs",
+    "build-explorer:cjs-esm": "rm -rf dist && rollup -c buildHelpers/rollup.explorer.cjs-esm.config.js && cp src/index.cjs dist/index.cjs && cp src/react/index.cjs dist/react/index.cjs && node ./buildHelpers/prepareDist.js",
     "build-explorer:umd": "rm -rf dist && rollup -c buildHelpers/rollup.explorer.umd.config.js",
     "build-sandbox:umd": "rm -rf dist && rollup -c buildHelpers/rollup.sandbox.umd.config.js",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
@@ -58,6 +58,7 @@
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-typescript": "^8.3.2",
     "@size-limit/preset-small-lib": "5.0.5",
+    "@types/fs-extra": "^9.0.13",
     "@types/react": "18.0.8",
     "@types/react-dom": "18.0.3",
     "@typescript-eslint/eslint-plugin": "5.21.0",
@@ -69,6 +70,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "4.5.0",
+    "fs-extra": "^10.1.0",
     "graphql": "15.8.0",
     "husky": "7.0.4",
     "prettier": "2.6.2",
@@ -84,7 +86,6 @@
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "use-deep-compare-effect": "^1.8.1"
-
   },
   "peerDependenciesMeta": {
     "react": {
@@ -97,6 +98,5 @@
       "optional": true
     }
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -80,9 +80,23 @@
     "tslib": "2.3.1",
     "typescript": "3.9.10"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "use-deep-compare-effect": "^1.8.1"
+
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "use-deep-compare-effect": {
+      "optional": true
+    }
+  },
+  "dependencies": {
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "npm run build-explorer:cjs-esm",
-    "build-explorer:cjs-esm": "rm -rf dist && rollup -c buildHelpers/rollup.explorer.cjs-esm.config.js && cp src/index.cjs dist/index.cjs",
+    "build-explorer:cjs-esm": "rm -rf dist && rollup -c buildHelpers/rollup.explorer.cjs-esm.config.js && cp src/index.cjs dist/index.cjs && cp src/react/index.cjs dist/react/index.cjs",
     "build-explorer:umd": "rm -rf dist && rollup -c buildHelpers/rollup.explorer.umd.config.js",
     "build-sandbox:umd": "rm -rf dist && rollup -c buildHelpers/rollup.sandbox.umd.config.js",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",

--- a/src/embeddedExplorer/examples/react-example/index.tsx
+++ b/src/embeddedExplorer/examples/react-example/index.tsx
@@ -2,7 +2,7 @@ import './index.css';
 // we alias react & react-dom to the same version in the main package.json
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
-import { ApolloExplorerReact } from '../../../react';
+import { ApolloExplorer } from '../../../react';
 import { useState } from 'react';
 import { exampleSchema } from './exampleSchema';
 
@@ -20,7 +20,7 @@ function App() {
       >
         Click me to change the theme
       </button>
-      <ApolloExplorerReact
+      <ApolloExplorer
         className="embedded-explorer"
         graphRef="acephei@current"
         endpointUrl="https://acephei-gateway.herokuapp.com"
@@ -50,7 +50,7 @@ function App() {
       >
         Click me to change the schema
       </button>
-      <ApolloExplorerReact
+      <ApolloExplorer
         className="embedded-explorer"
         schema={schema}
         endpointUrl="https://acephei-gateway.herokuapp.com"

--- a/src/embeddedExplorer/examples/react-example/index.tsx
+++ b/src/embeddedExplorer/examples/react-example/index.tsx
@@ -2,7 +2,7 @@ import './index.css';
 // we alias react & react-dom to the same version in the main package.json
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
-import { ApolloExplorerReact } from '../../../index';
+import { ApolloExplorerReact } from '../../../react';
 import { useState } from 'react';
 import { exampleSchema } from './exampleSchema';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 import { EmbeddedExplorer } from './embeddedExplorer/EmbeddedExplorer';
-import { ApolloExplorerReact } from './embeddedExplorer/react';
 
-export { EmbeddedExplorer as ApolloExplorer, ApolloExplorerReact };
+export { EmbeddedExplorer as ApolloExplorer };

--- a/src/react/index.cjs
+++ b/src/react/index.cjs
@@ -1,0 +1,6 @@
+'use strict';
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./index.production.min.js');
+} else {
+  module.exports = require('./index.development.js');
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,0 +1,1 @@
+export { ApolloExplorerReact } from '../embeddedExplorer/react';

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,1 +1,1 @@
-export { ApolloExplorerReact } from '../embeddedExplorer/react';
+export { ApolloExplorerReact as ApolloExplorer } from '../embeddedExplorer/react';


### PR DESCRIPTION
This PR changes the import style of our npm package from 

```
import { ApolloExplorer, ApolloExplorerReact } from '@apollo/explorer';
const { ApolloExplorer, ApolloExplorerReact } = require('@apollo/explorer');
```
to 
```
import { ApolloExplorer } from '@apollo/explorer';
import { ApolloExplorer } from '@apollo/explorer/react';
const { ApolloExplorer } = require('@apollo/explorer');
const { ApolloExplorer } = require('@apollo/explorer/react');
```

**How?**

I created a /react folder in /src with a single index.ts file that exports the React component, and specified this as an entry point for rollup to build. When the build is built, all of this is in the dist folder. When we publish to npm, we publish from the dist folder so folks can import from `@apollo/explorer/react` instead of `@apollo/explorer/dist/react`. 

The code is commented and I tested it with esm imports. We would ship this along with https://github.com/apollographql/embeddable-explorer/pull/123 as a new major version, and I would like to publish an alpha and make sure everything looks gucci before we go for it for reals. 

**Historical Context**

Hello! Welcome to the `embeddable-explorer` repo. Please take a look at the [README](https://github.com/apollographql/embeddable-explorer/blob/main/README.md).

Some context that would be helpful to know for reviewing in this repo: 
- We have 2 ways that we export the code that is build in this repo. We publish a umd file `embeddable-explorer.umd.production.min.js` to [this bucket](https://console.cloud.google.com/storage/browser/embeddable-explorer;tab=objects?forceOnBucketsSortingFiltering=false&project=mdg-services&prefix=&forceOnObjectsSortingFiltering=false&pli=1) on merge. This file is used by folks who select the CDN option in the Embed Explorer modal like so:

![Screen Shot 2022-06-06 at 6 15 25 PM](https://user-images.githubusercontent.com/14367451/172967743-2f40b74f-7494-43f2-85cd-f77fae6ae0cf.png)

We also have an npm package `@apollo/explorer` that is managed by [Changesets](https://github.com/changesets/changesets). This npm package uses the `build` command, which creates an esm & cjs build. The CJS build have a production & development version which is decided via `index.cjs` which, in this PR, is created by `writeCJSEntryFile.js`. 

I am pretty sure that the `publish-changeset` npm script is our publish script, but I want to publish an alpha to be sure. 

**Notes:** 
- The source maps here are pointing to ts files that are not included in the dist folder. What do people usually do for thei source maps? I looked at @apollo/client and the source maps there seem to point to things that don't exist either? How much do we care about source maps b/c we aren't adding the .ts files to our build? I am confused how they would be useful without the og ts files in our dist folder
- The code sandbox won't work since we changed the export path & name of the React export - manually change it to test!