### PR TITLE
make endpointUrl only required when schema is passed DON'T RELEASE UNTIL STUDIO PR IS OUT FOR A WHILE

### DIFF
--- a/packages/explorer/src/EmbeddedExplorer.ts
+++ b/packages/explorer/src/EmbeddedExplorer.ts
@@ -26,8 +26,6 @@ export interface BaseEmbeddableExplorerOptions {
   };
   persistExplorerState?: boolean; // defaults to 'false'
 
-  endpointUrl: string;
-
   // optional. defaults to `return fetch(url, fetchOptions)`
   handleRequest?: HandleRequest;
   // defaults to false. If you pass `handleRequest` that will override this.
@@ -44,6 +42,7 @@ export interface BaseEmbeddableExplorerOptions {
 interface EmbeddableExplorerOptionsWithSchema
   extends BaseEmbeddableExplorerOptions {
   schema: string | IntrospectionQuery;
+  endpointUrl: string;
   graphRef?: never;
 }
 
@@ -51,6 +50,7 @@ interface EmbeddableExplorerOptionsWithGraphRef
   extends BaseEmbeddableExplorerOptions {
   graphRef: string;
   schema?: never;
+  endpointUrl?: never;
 }
 
 export type EmbeddableExplorerOptions =
@@ -123,9 +123,11 @@ export class EmbeddedExplorer {
       throw new Error('"target" is required');
     }
 
-    if (!this.options.handleRequest && !this.options.endpointUrl) {
-      throw new Error(
-        '`endpointUrl` is required unless you write a custom `handleRequest`'
+    if ('endpointUrl' in this.options && 'graphRef' in this.options) {
+      // we can't throw here for backwards compat reasons. Folks on the cdn _latest bundle
+      // will still be passing this
+      console.warn(
+        'You may only specify an endpointUrl if you are manually passing a `schema`. If you pass a `graphRef`, you must configure your endpoint on your Studio graph.'
       );
     }
 

--- a/packages/explorer/src/examples/localDevelopmentExample.html
+++ b/packages/explorer/src/examples/localDevelopmentExample.html
@@ -28,7 +28,6 @@
       new window.EmbeddedExplorer({
         target: '#embeddableExplorer',
         graphRef: 'acephei@current',
-        endpointUrl: 'https://acephei-gateway.herokuapp.com',
         initialState: {
           document: `query Example {
 	me {

--- a/packages/explorer/src/examples/react-example/index.tsx
+++ b/packages/explorer/src/examples/react-example/index.tsx
@@ -23,7 +23,6 @@ function App() {
       <ApolloExplorer
         className="embedded-explorer"
         graphRef="acephei@current"
-        endpointUrl="https://acephei-gateway.herokuapp.com"
         initialState={{
           document: `query Example {
 	me {

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -99,7 +99,7 @@ export type IncomingEmbedMessage = MessageEvent;
 //     operationId: string;
 //     variables?: Record<string, string>;
 //     headers?: Record<string, string>;
-//     sandboxEndpointUrl?: string;
+//     endpointUrl?: string;
 //   }>
 // | MessageEvent<{
 //     name: typeof EXPLORER_LISTENING_FOR_SCHEMA;

--- a/packages/explorer/src/react/ApolloExplorer.tsx
+++ b/packages/explorer/src/react/ApolloExplorer.tsx
@@ -11,12 +11,14 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 interface EmbeddableExplorerOptionsWithSchema
   extends Omit<BaseEmbeddableExplorerOptions, 'target'> {
   schema: string | IntrospectionQuery;
+  endpointUrl: string;
   graphRef?: never;
 }
 
 interface EmbeddableExplorerOptionsWithGraphRef
   extends Omit<BaseEmbeddableExplorerOptions, 'target'> {
   graphRef: string;
+  endpointUrl?: never;
   schema?: never;
 }
 

--- a/packages/explorer/src/setupEmbedRelay.ts
+++ b/packages/explorer/src/setupEmbedRelay.ts
@@ -23,7 +23,7 @@ export function setupEmbedRelay({
   graphRef,
   autoInviteOptions,
 }: {
-  endpointUrl: string;
+  endpointUrl: string | undefined;
   handleRequest: HandleRequest;
   embeddedExplorerIFrameElement: HTMLIFrameElement;
   updateSchemaInEmbed: ({
@@ -78,11 +78,17 @@ export function setupEmbedRelay({
       // If the user is executing a query or mutation or subscription...
       if (isQueryOrMutation && data.operation && data.operationId) {
         // Extract the operation details from the event.data object
-        const { operation, operationId, operationName, variables, headers } =
-          data;
+        const {
+          operation,
+          operationId,
+          operationName,
+          variables,
+          headers,
+          endpointUrl: studioGraphEndpointUrl,
+        } = data;
         if (isQueryOrMutation) {
           executeOperation({
-            endpointUrl,
+            endpointUrl: endpointUrl ?? studioGraphEndpointUrl,
             handleRequest,
             operation,
             operationName,

--- a/packages/sandbox/src/setupSandboxEmbedRelay.ts
+++ b/packages/sandbox/src/setupSandboxEmbedRelay.ts
@@ -50,11 +50,11 @@ export function setupSandboxEmbedRelay({
         const {
           introspectionRequestBody,
           introspectionRequestHeaders,
-          endpointUrl,
+          sandboxEndpointUrl,
         } = data;
-        if (endpointUrl) {
+        if (sandboxEndpointUrl) {
           executeIntrospectionRequest({
-            endpointUrl,
+            endpointUrl: sandboxEndpointUrl,
             introspectionRequestBody,
             headers: introspectionRequestHeaders,
             embeddedIFrameElement: embeddedSandboxIFrameElement,

--- a/packages/sandbox/src/setupSandboxEmbedRelay.ts
+++ b/packages/sandbox/src/setupSandboxEmbedRelay.ts
@@ -76,10 +76,14 @@ export function setupSandboxEmbedRelay({
           variables,
           headers,
           endpointUrl,
+          // this can be deleted in Fall 2022
+          // it is just here to be backwards compatible with old
+          // studio versions (service workers)
+          sandboxEndpointUrl,
         } = data;
         if (isQueryOrMutation && endpointUrl) {
           executeOperation({
-            endpointUrl,
+            endpointUrl: endpointUrl ?? sandboxEndpointUrl,
             handleRequest,
             operation,
             operationName,

--- a/packages/sandbox/src/setupSandboxEmbedRelay.ts
+++ b/packages/sandbox/src/setupSandboxEmbedRelay.ts
@@ -50,11 +50,11 @@ export function setupSandboxEmbedRelay({
         const {
           introspectionRequestBody,
           introspectionRequestHeaders,
-          sandboxEndpointUrl,
+          endpointUrl,
         } = data;
-        if (sandboxEndpointUrl) {
+        if (endpointUrl) {
           executeIntrospectionRequest({
-            endpointUrl: sandboxEndpointUrl,
+            endpointUrl,
             introspectionRequestBody,
             headers: introspectionRequestHeaders,
             embeddedIFrameElement: embeddedSandboxIFrameElement,
@@ -75,11 +75,11 @@ export function setupSandboxEmbedRelay({
           operationName,
           variables,
           headers,
-          sandboxEndpointUrl,
+          endpointUrl,
         } = data;
-        if (isQueryOrMutation && sandboxEndpointUrl) {
+        if (isQueryOrMutation && endpointUrl) {
           executeOperation({
-            endpointUrl: sandboxEndpointUrl,
+            endpointUrl,
             handleRequest,
             operation,
             operationName,


### PR DESCRIPTION
studio PR: 

https://github.com/mdg-private/studio-ui/pull/6424

This would be a major npm update since the types would throw. I think we'd also want a major npm update for the new sandbox package & /react imports - se we'd bundle these