### PR TITLE
NEBULA-1385: Add initialState config for sandbox

### DIFF
--- a/.changeset/fast-bulldogs-bathe.md
+++ b/.changeset/fast-bulldogs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@apollo/explorer': minor
+---
+
+Add initialState config for sandbox

--- a/src/embeddedExplorer/EmbeddedExplorer.ts
+++ b/src/embeddedExplorer/EmbeddedExplorer.ts
@@ -11,13 +11,14 @@ import {
 } from '../helpers/postMessageRelayHelpers';
 import { setupEmbedRelay } from './setupEmbedRelay';
 import packageJSON from '../../package.json';
+import type { JSONObject } from '../types';
 
 export interface BaseEmbeddableExplorerOptions {
   target: string | HTMLElement; // HTMLElement is to accomodate people who might prefer to pass in a ref
 
   initialState?: {
     document?: string;
-    variables?: Record<string, any>;
+    variables?: JSONObject;
     headers?: Record<string, string>;
     displayOptions: {
       docsPanelState?: 'open' | 'closed'; // default to 'open',

--- a/src/embeddedSandbox/EmbeddedSandbox.ts
+++ b/src/embeddedSandbox/EmbeddedSandbox.ts
@@ -11,6 +11,7 @@ import {
 } from '../helpers/postMessageRelayHelpers';
 import { setupSandboxEmbedRelay } from './setupSandboxEmbedRelay';
 import packageJSON from '../../package.json';
+import type { JSONObject } from '../types';
 
 export interface EmbeddableSandboxOptions {
   target: string | HTMLElement; // HTMLElement is to accomodate people who might prefer to pass in a ref
@@ -18,7 +19,7 @@ export interface EmbeddableSandboxOptions {
 
   initialState?: {
     document?: string;
-    variables?: Record<string, any>;
+    variables?: JSONObject;
     headers?: Record<string, string>;
   };
 

--- a/src/embeddedSandbox/EmbeddedSandbox.ts
+++ b/src/embeddedSandbox/EmbeddedSandbox.ts
@@ -21,7 +21,6 @@ export interface EmbeddableSandboxOptions {
     variables?: Record<string, any>;
     headers?: Record<string, string>;
   };
-  persistExplorerState?: boolean; // defaults to 'false'
 
   // optional. defaults to `return fetch(url, fetchOptions)`
   handleRequest?: HandleRequest;
@@ -62,7 +61,7 @@ export class EmbeddedSandbox {
 
   injectEmbed() {
     let element: HTMLElement | null;
-    const { target, persistExplorerState } = this.options;
+    const { target } = this.options;
 
     const {
       document: initialDocument,
@@ -81,7 +80,6 @@ export class EmbeddedSandbox {
       defaultHeaders: headers
         ? encodeURIComponent(JSON.stringify(headers))
         : undefined,
-      shouldPersistState: !!persistExplorerState,
       version: packageJSON.version,
     };
 


### PR DESCRIPTION
## Context
[JIRA](https://apollographql.atlassian.net/browse/NEBULA-1385)

## What changed
- Added initialState with document, headers and variables for embeddable sandbox

## How to test
- Checkout to `william/sandbox-initial-state` on `embeddable-explorer` repo
- Checkout to `william/explorer-everywhere/sandbox-initial-state` on `studio-ui` repo
- Change `constants.ts` to `EMBEDDABLE_SANDBOX_URL =
  'https://embed.apollo.local:3000/sandbox/explorer';`
- Add an initial state to the embed configuration, for example:
```
initialState: {
document: `query Test {
  me {
    id
  }
}`,
variables: {
  test: 'abcxyz',
},
headers: {
  'key': 'value'
},
```
- `npm run build-sandbox:umd` on embeddable-explorer
- `npm run start:embedded` on studio-ui
- Open localDevelopmentExample for embedded Sandbox on Go Live
- Close all tabs to see initial state

[Corresponding studio-ui PR](https://github.com/mdg-private/studio-ui/pull/6453)