### PR TITLE
add version-0 to release branch options

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - maya/version-0
 
 jobs:
   release:


### PR DESCRIPTION
We might want to add commits to branch version-0 which is the source of truth for @apollo/explorer < 1.0.0. 

This will check that branch for changes as well!