### PR TITLE
Fix relative path for react-example alias

### DIFF
--- a/.changeset/silver-fans-try.md
+++ b/.changeset/silver-fans-try.md
@@ -1,0 +1,6 @@
+---
+'@apollo/explorer': patch
+'@apollo/sandbox': patch
+---
+
+Fix react-example alias

--- a/packages/explorer/src/examples/react-example/package.json
+++ b/packages/explorer/src/examples/react-example/package.json
@@ -10,8 +10,7 @@
   },
   "alias": {
     "react": "../../../../../node_modules/react",
-    "react-dom": "../../../../../node_modules/react-dom",
-    "scheduler/tracing": "../../../node_modules/scheduler/tracing-profiling"
+    "react-dom": "../../../../../node_modules/react-dom"
   },
   "devDependencies": {
     "@types/react": "18.0.5",

--- a/packages/explorer/src/examples/react-example/package.json
+++ b/packages/explorer/src/examples/react-example/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
   },
   "alias": {
-    "react": "../../../../node_modules/react",
-    "react-dom": "../../../../node_modules/react-dom",
+    "react": "../../../../../node_modules/react",
+    "react-dom": "../../../../../node_modules/react-dom",
     "scheduler/tracing": "../../../node_modules/scheduler/tracing-profiling"
   },
   "devDependencies": {

--- a/packages/sandbox/src/examples/react-example/package.json
+++ b/packages/sandbox/src/examples/react-example/package.json
@@ -10,8 +10,7 @@
   },
   "alias": {
     "react": "../../../../../node_modules/react",
-    "react-dom": "../../../../../node_modules/react-dom",
-    "scheduler/tracing": "../../../node_modules/scheduler/tracing-profiling"
+    "react-dom": "../../../../../node_modules/react-dom"
   },
   "devDependencies": {
     "@types/react": "18.0.5",

--- a/packages/sandbox/src/examples/react-example/package.json
+++ b/packages/sandbox/src/examples/react-example/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
   },
   "alias": {
-    "react": "../../../../node_modules/react",
-    "react-dom": "../../../../node_modules/react-dom",
+    "react": "../../../../../node_modules/react",
+    "react-dom": "../../../../../node_modules/react-dom",
     "scheduler/tracing": "../../../node_modules/scheduler/tracing-profiling"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm run start` was not working for react-example

The files were moved, so the relative path needed to be fixed