### PR TITLE
🐛 move dependencies into individual package.jsons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,6 @@
         "packages/explorer",
         "packages/sandbox"
       ],
-      "dependencies": {
-        "graphql-ws": "^5.9.0",
-        "subscriptions-transport-ws": "^0.11.0"
-      },
       "devDependencies": {
         "@babel/core": "^7.18.5",
         "@changesets/changelog-github": "0.4.4",
@@ -9847,8 +9843,12 @@
     },
     "packages/explorer": {
       "name": "@apollo/explorer",
-      "version": "0.6.0",
+      "version": "1.1.0",
       "license": "MIT",
+      "dependencies": {
+        "graphql-ws": "^5.9.0",
+        "subscriptions-transport-ws": "^0.11.0"
+      },
       "engines": {
         "node": ">=12.0",
         "npm": ">=7.0"
@@ -9872,8 +9872,12 @@
     },
     "packages/sandbox": {
       "name": "@apollo/sandbox",
-      "version": "0.6.0",
+      "version": "0.2.0",
       "license": "MIT",
+      "dependencies": {
+        "graphql-ws": "^5.9.0",
+        "subscriptions-transport-ws": "^0.11.0"
+      },
       "engines": {
         "node": ">=12.0",
         "npm": ">=7.0"
@@ -9903,11 +9907,17 @@
     },
     "@apollo/explorer": {
       "version": "file:packages/explorer",
-      "requires": {}
+      "requires": {
+        "graphql-ws": "^5.9.0",
+        "subscriptions-transport-ws": "^0.11.0"
+      }
     },
     "@apollo/sandbox": {
       "version": "file:packages/sandbox",
-      "requires": {}
+      "requires": {
+        "graphql-ws": "^5.9.0",
+        "subscriptions-transport-ws": "^0.11.0"
+      }
     },
     "@babel/code-frame": {
       "version": "7.16.7",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,5 @@
     "typescript": "3.9.10"
   },
   "dependencies": {
-    "graphql-ws": "^5.9.0",
-    "subscriptions-transport-ws": "^0.11.0"
   }
 }

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -64,5 +64,8 @@
       "optional": true
     }
   },
-  "dependencies": {}
+  "dependencies": {
+    "graphql-ws": "^5.9.0",
+    "subscriptions-transport-ws": "^0.11.0"
+  }
 }

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -60,5 +60,8 @@
       "optional": true
     }
   },
-  "dependencies": {}
+  "dependencies": {
+    "graphql-ws": "^5.9.0",
+    "subscriptions-transport-ws": "^0.11.0"
+  }
 }


### PR DESCRIPTION
I think I told Will the wrong thing. I just tested sandbox 0.2.0 which we released today & was getting a dependency not found error. I should have checked the code sandboxes - I think this should fix it.