### PR TITLE
Add test-only local url option

### DIFF
--- a/packages/explorer/src/EmbeddedExplorer.ts
+++ b/packages/explorer/src/EmbeddedExplorer.ts
@@ -59,17 +59,23 @@ export type EmbeddableExplorerOptions =
   | EmbeddableExplorerOptionsWithSchema
   | EmbeddableExplorerOptionsWithGraphRef;
 
+type InternalEmbeddableExplorerOptions = EmbeddableExplorerOptions & {
+  __testLocal__?: boolean;
+};
+
 let idCounter = 0;
 
 export class EmbeddedExplorer {
-  options: EmbeddableExplorerOptions;
+  options: InternalEmbeddableExplorerOptions;
   handleRequest: HandleRequest;
   embeddedExplorerURL: string;
   embeddedExplorerIFrameElement: HTMLIFrameElement;
   uniqueEmbedInstanceId: number;
+  __testLocal__: boolean;
   private disposable: { dispose: () => void };
   constructor(options: EmbeddableExplorerOptions) {
-    this.options = options;
+    this.options = options as InternalEmbeddableExplorerOptions;
+    this.__testLocal__ = !!this.options.__testLocal__;
     this.validateOptions();
     this.handleRequest =
       this.options.handleRequest ??
@@ -85,6 +91,7 @@ export class EmbeddedExplorer {
       schema: 'schema' in this.options ? this.options.schema : undefined,
       graphRef: 'graphRef' in this.options ? this.options.graphRef : undefined,
       autoInviteOptions: this.options.autoInviteOptions,
+      __testLocal__: this.__testLocal__,
     });
   }
 
@@ -172,7 +179,7 @@ export class EmbeddedExplorer {
       .filter(([_, value]) => value !== undefined)
       .map(([key, value]) => `${key}=${value}`)
       .join('&');
-    return `${EMBEDDABLE_EXPLORER_URL}?${queryString}`;
+    return `${EMBEDDABLE_EXPLORER_URL(this.__testLocal__)}?${queryString}`;
   };
 
   updateSchemaInEmbed({
@@ -186,7 +193,7 @@ export class EmbeddedExplorer {
         schema,
       },
       embeddedIFrameElement: this.embeddedExplorerIFrameElement,
-      embedUrl: EMBEDDABLE_EXPLORER_URL,
+      embedUrl: EMBEDDABLE_EXPLORER_URL(this.__testLocal__),
     });
   }
 }

--- a/packages/explorer/src/helpers/constants.ts
+++ b/packages/explorer/src/helpers/constants.ts
@@ -1,8 +1,8 @@
 // URL for any embedded Explorer iframe
-export const EMBEDDABLE_EXPLORER_URL =
-  'https://explorer.embed.apollographql.com';
-export const EMBEDDABLE_SANDBOX_URL =
-  'https://sandbox.embed.apollographql.com/sandbox/explorer';
+export const EMBEDDABLE_EXPLORER_URL = (__testLocal__ = false) =>
+  __testLocal__
+    ? 'https://embed.apollo.local:3000'
+    : 'https://explorer.embed.apollographql.com';
 
 // Message types for Explorer state
 export const EXPLORER_LISTENING_FOR_SCHEMA = 'ExplorerListeningForSchema';

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -5,7 +5,6 @@ import type {
 } from 'graphql';
 import {
   PARTIAL_AUTHENTICATION_TOKEN_RESPONSE,
-  EMBEDDABLE_SANDBOX_URL,
   EXPLORER_QUERY_MUTATION_RESPONSE,
   HANDSHAKE_RESPONSE,
   SCHEMA_ERROR,
@@ -235,62 +234,6 @@ export function executeOperation({
         },
         embeddedIFrameElement,
         embedUrl,
-      });
-    });
-}
-
-export function executeIntrospectionRequest({
-  endpointUrl,
-  headers,
-  introspectionRequestBody,
-  embeddedIFrameElement,
-}: {
-  endpointUrl: string;
-  embeddedIFrameElement: HTMLIFrameElement;
-  headers?: Record<string, string>;
-  introspectionRequestBody: string;
-}) {
-  const { query, operationName } = JSON.parse(introspectionRequestBody) as {
-    query: string;
-    operationName: string;
-  };
-  return fetch(endpointUrl, {
-    method: 'POST',
-    headers: getHeadersWithContentType(headers),
-    body: JSON.stringify({
-      query,
-      operationName,
-    }),
-  })
-    .then((response) => response.json())
-    .then((response) => {
-      if (response.errors && response.errors.length) {
-        sendPostMessageToEmbed({
-          message: {
-            name: SCHEMA_ERROR,
-            errors: response.errors,
-          },
-          embeddedIFrameElement,
-          embedUrl: EMBEDDABLE_SANDBOX_URL,
-        });
-      }
-      sendPostMessageToEmbed({
-        message: {
-          name: SCHEMA_RESPONSE,
-          schema: response.data,
-        },
-        embeddedIFrameElement,
-        embedUrl: EMBEDDABLE_SANDBOX_URL,
-      });
-    })
-    .catch((error) => {
-      sendPostMessageToEmbed({
-        message: {
-          name: SCHEMA_ERROR,
-          error: error,
-        },
-        embeddedIFrameElement,
-        embedUrl: EMBEDDABLE_SANDBOX_URL,
       });
     });
 }

--- a/packages/explorer/src/setupEmbedRelay.ts
+++ b/packages/explorer/src/setupEmbedRelay.ts
@@ -27,6 +27,7 @@ export function setupEmbedRelay({
   schema,
   graphRef,
   autoInviteOptions,
+  __testLocal__,
 }: {
   endpointUrl: string | undefined;
   handleRequest: HandleRequest;
@@ -42,8 +43,9 @@ export function setupEmbedRelay({
     accountId: string;
     inviteToken: string;
   };
+  __testLocal__: boolean;
 }) {
-  const embedUrl = EMBEDDABLE_EXPLORER_URL;
+  const embedUrl = EMBEDDABLE_EXPLORER_URL(__testLocal__);
   // Callback definition
   const onPostMessageReceived = (event: IncomingEmbedMessage) => {
     handleAuthenticationPostMessage({

--- a/packages/sandbox/src/helpers/constants.ts
+++ b/packages/sandbox/src/helpers/constants.ts
@@ -1,8 +1,7 @@
-// URL for any embedded Explorer iframe
-export const EMBEDDABLE_EXPLORER_URL =
-  'https://explorer.embed.apollographql.com';
-export const EMBEDDABLE_SANDBOX_URL =
-  'https://sandbox.embed.apollographql.com/sandbox/explorer';
+export const EMBEDDABLE_SANDBOX_URL = (__testLocal__ = false) =>
+  __testLocal__
+    ? 'https://embed.apollo.local:3000/sandbox/explorer'
+    : 'https://sandbox.embed.apollographql.com/sandbox/explorer';
 
 // Message types for Explorer state
 export const EXPLORER_LISTENING_FOR_SCHEMA = 'ExplorerListeningForSchema';

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -5,7 +5,6 @@ import type {
 } from 'graphql';
 import {
   PARTIAL_AUTHENTICATION_TOKEN_RESPONSE,
-  EMBEDDABLE_SANDBOX_URL,
   EXPLORER_QUERY_MUTATION_RESPONSE,
   HANDSHAKE_RESPONSE,
   SCHEMA_ERROR,
@@ -244,11 +243,13 @@ export function executeIntrospectionRequest({
   headers,
   introspectionRequestBody,
   embeddedIFrameElement,
+  embedUrl,
 }: {
   endpointUrl: string;
   embeddedIFrameElement: HTMLIFrameElement;
   headers?: Record<string, string>;
   introspectionRequestBody: string;
+  embedUrl: string;
 }) {
   const { query, operationName } = JSON.parse(introspectionRequestBody) as {
     query: string;
@@ -273,7 +274,7 @@ export function executeIntrospectionRequest({
             errors: response.errors,
           },
           embeddedIFrameElement,
-          embedUrl: EMBEDDABLE_SANDBOX_URL,
+          embedUrl,
         });
       }
       sendPostMessageToEmbed({
@@ -284,7 +285,7 @@ export function executeIntrospectionRequest({
           schema: response.data,
         },
         embeddedIFrameElement,
-        embedUrl: EMBEDDABLE_SANDBOX_URL,
+        embedUrl,
       });
     })
     .catch((error) => {
@@ -296,7 +297,7 @@ export function executeIntrospectionRequest({
           error: error,
         },
         embeddedIFrameElement,
-        embedUrl: EMBEDDABLE_SANDBOX_URL,
+        embedUrl,
       });
     });
 }

--- a/packages/sandbox/src/setupSandboxEmbedRelay.ts
+++ b/packages/sandbox/src/setupSandboxEmbedRelay.ts
@@ -19,11 +19,13 @@ import { executeSubscription } from './helpers/subscriptionPostMessageRelayHelpe
 export function setupSandboxEmbedRelay({
   handleRequest,
   embeddedSandboxIFrameElement,
+  __testLocal__,
 }: {
   handleRequest: HandleRequest;
   embeddedSandboxIFrameElement: HTMLIFrameElement;
+  __testLocal__: boolean;
 }) {
-  const embedUrl = EMBEDDABLE_SANDBOX_URL;
+  const embedUrl = EMBEDDABLE_SANDBOX_URL(__testLocal__);
   // Callback definition
   const onPostMessageReceived = (event: IncomingEmbedMessage) => {
     handleAuthenticationPostMessage({
@@ -61,6 +63,7 @@ export function setupSandboxEmbedRelay({
             introspectionRequestBody,
             headers: introspectionRequestHeaders,
             embeddedIFrameElement: embeddedSandboxIFrameElement,
+            embedUrl,
           });
         }
       }


### PR DESCRIPTION
We want to add smoke tests for the embeddable Explorer / Sandbox. To do this in cypress / circle ci, we need to spin up a local embed build of studio-ui via `npm run start:embedded`, and then we need to spin up a little html embed site that uses the embeddable-explorer code on the cdn to embed the site, and we will need to point to the local https://embed.apollo.local:3000 running site.

We can use this option to point to the local running site instead of studio developed.