### PR TITLE
Add opt-in query param for Studio telemetry & cookie notice

### DIFF
--- a/.changeset/hungry-tips-speak.md
+++ b/.changeset/hungry-tips-speak.md
@@ -1,0 +1,6 @@
+---
+"@apollo/explorer": patch
+"@apollo/sandbox": patch
+---
+
+Add opt-in query param for Studio telemetry & cookie notice

--- a/packages/explorer/src/EmbeddedExplorer.ts
+++ b/packages/explorer/src/EmbeddedExplorer.ts
@@ -173,6 +173,7 @@ export class EmbeddedExplorer {
       shouldShowGlobalHeader: true,
       parentSupportsSubscriptions: !!graphRef,
       version: packageJSON.version,
+      runTelemetry: true,
     };
 
     const queryString = Object.entries(queryParams)

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -90,6 +90,7 @@ export class EmbeddedSandbox {
         : undefined,
       parentSupportsSubscriptions: true,
       version: packageJSON.version,
+      runTelemetry: true,
     };
 
     const queryString = Object.entries(queryParams)


### PR DESCRIPTION
We don't want to run telemetry on dev tools: https://apollograph.slack.com/archives/C01GC140SUV/p1655387856372719

So we are going to opt out by default on the embedded sites, but lets pass an opt in from here! So all newer versions get telemetry