### PR TITLE
NEBULA-1271: Support @defer in embedded Explorer and embedded Sandbox

### DIFF
--- a/.changeset/lemon-glasses-bow.md
+++ b/.changeset/lemon-glasses-bow.md
@@ -1,0 +1,6 @@
+---
+'@apollo/explorer': minor
+'@apollo/sandbox': minor
+---
+
+Added support for @defer and @stream

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "packages/explorer",
         "packages/sandbox"
       ],
+      "dependencies": {
+        "zen-observable-ts": "^1.1.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.18.5",
         "@changesets/changelog-github": "0.4.4",
@@ -1626,6 +1629,11 @@
       "version": "6.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/zen-observable": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.21.0",
@@ -9038,8 +9046,9 @@
     },
     "node_modules/typescript": {
       "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9841,9 +9850,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "dependencies": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
+      }
+    },
     "packages/explorer": {
       "name": "@apollo/explorer",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "graphql-ws": "^5.9.0",
@@ -9872,7 +9895,7 @@
     },
     "packages/sandbox": {
       "name": "@apollo/sandbox",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "graphql-ws": "^5.9.0",
@@ -11061,6 +11084,11 @@
     "@types/semver": {
       "version": "6.2.3",
       "dev": true
+    },
+    "@types/zen-observable": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.21.0",
@@ -15960,6 +15988,8 @@
     },
     "typescript": {
       "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
     },
     "unbox-primitive": {
@@ -16518,6 +16548,20 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "requires": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,5 +82,6 @@
     "typescript": "3.9.10"
   },
   "dependencies": {
+    "zen-observable-ts": "^1.1.0"
   }
 }

--- a/packages/explorer/src/helpers/constants.ts
+++ b/packages/explorer/src/helpers/constants.ts
@@ -14,6 +14,9 @@ export const SCHEMA_RESPONSE = 'SchemaResponse';
 // Message types for queries and mutations
 export const EXPLORER_QUERY_MUTATION_REQUEST = 'ExplorerRequest';
 export const EXPLORER_QUERY_MUTATION_RESPONSE = 'ExplorerResponse';
+export const EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE =
+  'ExplorerPartialResponse';
+export const TRACE_KEY = 'ftv1';
 
 // Message types for subscriptions
 export const EXPLORER_SUBSCRIPTION_REQUEST = 'ExplorerSubscriptionRequest';

--- a/packages/explorer/src/helpers/constants.ts
+++ b/packages/explorer/src/helpers/constants.ts
@@ -14,8 +14,6 @@ export const SCHEMA_RESPONSE = 'SchemaResponse';
 // Message types for queries and mutations
 export const EXPLORER_QUERY_MUTATION_REQUEST = 'ExplorerRequest';
 export const EXPLORER_QUERY_MUTATION_RESPONSE = 'ExplorerResponse';
-export const EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE =
-  'ExplorerPartialResponse';
 export const TRACE_KEY = 'ftv1';
 
 // Message types for subscriptions

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -16,7 +16,7 @@ import {
   EXPLORER_SUBSCRIPTION_RESPONSE,
   EXPLORER_SET_SOCKET_ERROR,
   EXPLORER_SET_SOCKET_STATUS,
-  EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
+  TRACE_KEY,
 } from './constants';
 import {
   MultipartResponse,
@@ -90,18 +90,16 @@ export type OutgoingEmbedMessage =
       name: typeof EXPLORER_QUERY_MUTATION_RESPONSE;
       operationId: string;
       response: {
-        data?: JSONValue;
+        data?: Record<string, unknown> | JSONValue;
         error?: ResponseError;
-        errors?: [ResponseError];
+        errors?: GraphQLError[];
         status?: number;
-        headers?: Headers;
+        headers?: Headers | Record<string, string>;
         hasNext?: boolean;
+        path?: Array<string | number>;
+        size?: number;
+        extensions?: { [TRACE_KEY]?: string };
       };
-    }
-  | {
-      name: typeof EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE;
-      operationId: string;
-      response: MultipartResponse;
     }
   | {
       name: typeof EXPLORER_SUBSCRIPTION_RESPONSE;
@@ -225,15 +223,13 @@ export function executeOperation({
               message: {
                 // Include the same operation ID in the response message's name
                 // so the Explorer knows which operation it's associated with
-                name: EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
+                name: EXPLORER_QUERY_MUTATION_RESPONSE,
                 operationId,
                 response: {
-                  data: {
-                    data: data.data.data,
-                    errors: data.data.errors,
-                    extensions: data.data.extensions,
-                    path: data.data.path,
-                  },
+                  data: data.data.data,
+                  errors: data.data.errors,
+                  extensions: data.data.extensions,
+                  path: data.data.path,
                   status: response.status,
                   headers: responseHeaders,
                   hasNext: true,
@@ -249,13 +245,11 @@ export function executeOperation({
               message: {
                 // Include the same operation ID in the response message's name
                 // so the Explorer knows which operation it's associated with
-                name: EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
+                name: EXPLORER_QUERY_MUTATION_RESPONSE,
                 operationId,
                 response: {
-                  data: {
-                    data: null,
-                    error: { message: err },
-                  },
+                  data: null,
+                  error: { message: err },
                   size: 0,
                   hasNext: false,
                 },
@@ -269,10 +263,10 @@ export function executeOperation({
               message: {
                 // Include the same operation ID in the response message's name
                 // so the Explorer knows which operation it's associated with
-                name: EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
+                name: EXPLORER_QUERY_MUTATION_RESPONSE,
                 operationId,
                 response: {
-                  data: { data: null },
+                  data: null,
                   size: 0,
                   status: response.status,
                   headers: responseHeaders,

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -249,7 +249,10 @@ export function executeOperation({
                 operationId,
                 response: {
                   data: null,
-                  error: { message: err },
+                  error: {
+                    message: err.message,
+                    ...(err.stack ? { stack: err.stack } : {}),
+                  },
                   size: 0,
                   hasNext: false,
                 },

--- a/packages/explorer/src/helpers/readMultipartWebStream.ts
+++ b/packages/explorer/src/helpers/readMultipartWebStream.ts
@@ -1,15 +1,21 @@
 import type { Observer } from 'zen-observable-ts';
 import type { GraphQLError } from 'graphql';
+import type { JSONValue } from './types';
+import type { ResponseError } from './postMessageRelayHelpers';
 
 const TRACE_KEY = 'ftv1';
 export interface MultipartResponse {
   data: {
     path?: Array<string | number>;
-    data: Array<unknown> | Record<string, unknown>;
+    data: Array<unknown> | Record<string, unknown> | JSONValue | unknown[];
     errors?: Array<GraphQLError>;
+    error?: ResponseError;
     extensions?: { [TRACE_KEY]?: string };
   };
   size: number;
+  status?: number;
+  headers?: Record<string, string>;
+  hasNext?: boolean;
 }
 
 export function readMultipartWebStream(

--- a/packages/explorer/src/helpers/readMultipartWebStream.ts
+++ b/packages/explorer/src/helpers/readMultipartWebStream.ts
@@ -1,0 +1,142 @@
+import type { Observer } from 'zen-observable-ts';
+import type { GraphQLError } from 'graphql';
+
+const TRACE_KEY = 'ftv1';
+export interface MultipartResponse {
+  data: {
+    path?: Array<string | number>;
+    data: Array<unknown> | Record<string, unknown>;
+    errors?: Array<GraphQLError>;
+    extensions?: { [TRACE_KEY]?: string };
+  };
+  size: number;
+}
+
+export function readMultipartWebStream(
+  response: Response,
+  contentType: string,
+  observer: Observer<MultipartResponse>
+) {
+  if (response.body === null) {
+    throw new Error('Missing body');
+  } else if (typeof response.body.tee !== 'function') {
+    // not sure if we actually need this check in explorer?
+    throw new Error(
+      'Streaming bodies not supported by provided fetch implementation'
+    );
+  }
+
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+
+  // TODO: better parsing of boundary attribute?
+  const messageBoundary = `--${(
+    contentType.split('boundary=')[1] || '-'
+  ).replace(/(^('|"))|(('|")$)/g, '')}`;
+  // TODO: End message boundary???
+  const reader = response.body.getReader();
+  function readMultipartStream() {
+    reader
+      .read()
+      .then((iteration) => {
+        if (iteration.done) {
+          observer.complete?.();
+          return;
+        }
+
+        const chunk = decoder.decode(iteration.value);
+        buffer += chunk;
+
+        // buffer index
+        let bi = buffer.indexOf(messageBoundary);
+        while (bi > -1) {
+          const message = buffer.slice(0, bi);
+          buffer = buffer.slice(bi + messageBoundary.length);
+
+          if (message.trim()) {
+            const i = message.indexOf('\r\n\r\n');
+
+            // make sure header content type is valid
+            message
+              .slice(0, i)
+              .split('\n')
+              .forEach((line) => {
+                const indexOfColon = line.indexOf(':');
+                if (
+                  indexOfColon > -1 &&
+                  line.slice(0, indexOfColon).trim().toLowerCase() ===
+                    'content-type'
+                ) {
+                  if (
+                    line.slice(indexOfColon + 1).indexOf('application/json') ===
+                    -1
+                  ) {
+                    throw new Error('Unsupported patch content type'); // TODO: handle this case
+                  }
+                }
+              });
+
+            const bodyText = message.slice(i);
+            try {
+              observer.next?.({
+                data: JSON.parse(bodyText),
+                size: chunk.length,
+              });
+            } catch (err) {
+              // const parseError = err as ServerParseError;
+              // parseError.name = 'ServerParseError';
+              // parseError.response = response;
+              // parseError.statusCode = response.status;
+              // parseError.bodyText = bodyText;
+              throw err;
+            }
+          }
+
+          bi = buffer.indexOf(messageBoundary);
+        }
+
+        readMultipartStream();
+      })
+      .catch((err) => {
+        if (err.name === 'AbortError') return;
+        // if it is a network error, BUT there is graphql result info fire
+        // the next observer before calling error this gives apollo-client
+        // (and react-apollo) the `graphqlErrors` and `networkErrors` to
+        // pass to UI this should only happen if we *also* have data as
+        // part of the response key per the spec
+        if (err.result && err.result.errors && err.result.data) {
+          // if we don't call next, the UI can only show networkError
+          // because AC didn't get any graphqlErrors this is graphql
+          // execution result info (i.e errors and possibly data) this is
+          // because there is no formal spec how errors should translate to
+          // http status codes. So an auth error (401) could have both data
+          // from a public field, errors from a private field, and a status
+          // of 401
+          // {
+          //  user { // this will have errors
+          //    firstName
+          //  }
+          //  products { // this is public so will have data
+          //    cost
+          //  }
+          // }
+          //
+          // the result of above *could* look like this:
+          // {
+          //   data: { products: [{ cost: "$10" }] },
+          //   errors: [{
+          //      message: 'your session has timed out',
+          //      path: []
+          //   }]
+          // }
+          // status code of above would be a 401
+          // in the UI you want to show data where you can, errors as data where you can
+          // and use correct http status codes
+          observer.next?.({ data: err.result, size: Infinity });
+        }
+
+        observer.error?.(err);
+      });
+  }
+  readMultipartStream();
+}

--- a/packages/explorer/src/helpers/readMultipartWebStream.ts
+++ b/packages/explorer/src/helpers/readMultipartWebStream.ts
@@ -2,12 +2,12 @@ import type { Observer } from 'zen-observable-ts';
 import type { GraphQLError } from 'graphql';
 import type { JSONValue } from './types';
 import type { ResponseError } from './postMessageRelayHelpers';
+import type { TRACE_KEY } from './constants';
 
-const TRACE_KEY = 'ftv1';
 export interface MultipartResponse {
   data: {
     path?: Array<string | number>;
-    data: Array<unknown> | Record<string, unknown> | JSONValue | unknown[];
+    data: Record<string, unknown> | JSONValue;
     errors?: Array<GraphQLError>;
     error?: ResponseError;
     extensions?: { [TRACE_KEY]?: string };

--- a/packages/sandbox/src/helpers/constants.ts
+++ b/packages/sandbox/src/helpers/constants.ts
@@ -13,8 +13,6 @@ export const SCHEMA_RESPONSE = 'SchemaResponse';
 // Message types for queries and mutations
 export const EXPLORER_QUERY_MUTATION_REQUEST = 'ExplorerRequest';
 export const EXPLORER_QUERY_MUTATION_RESPONSE = 'ExplorerResponse';
-export const EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE =
-  'ExplorerPartialResponse';
 export const TRACE_KEY = 'ftv1';
 
 // Message types for subscriptions

--- a/packages/sandbox/src/helpers/constants.ts
+++ b/packages/sandbox/src/helpers/constants.ts
@@ -13,6 +13,9 @@ export const SCHEMA_RESPONSE = 'SchemaResponse';
 // Message types for queries and mutations
 export const EXPLORER_QUERY_MUTATION_REQUEST = 'ExplorerRequest';
 export const EXPLORER_QUERY_MUTATION_RESPONSE = 'ExplorerResponse';
+export const EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE =
+  'ExplorerPartialResponse';
+export const TRACE_KEY = 'ftv1';
 
 // Message types for subscriptions
 export const EXPLORER_SUBSCRIPTION_REQUEST = 'ExplorerSubscriptionRequest';

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -16,7 +16,7 @@ import {
   EXPLORER_SUBSCRIPTION_RESPONSE,
   EXPLORER_SET_SOCKET_ERROR,
   EXPLORER_SET_SOCKET_STATUS,
-  EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
+  TRACE_KEY,
 } from './constants';
 import {
   MultipartResponse,
@@ -90,18 +90,16 @@ export type OutgoingEmbedMessage =
       name: typeof EXPLORER_QUERY_MUTATION_RESPONSE;
       operationId: string;
       response: {
-        data?: JSONValue;
+        data?: Record<string, unknown> | JSONValue;
         error?: ResponseError;
-        errors?: [ResponseError];
+        errors?: GraphQLError[];
         status?: number;
-        headers?: Headers;
+        headers?: Headers | Record<string, string>;
         hasNext?: boolean;
+        path?: Array<string | number>;
+        size?: number;
+        extensions?: { [TRACE_KEY]?: string };
       };
-    }
-  | {
-      name: typeof EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE;
-      operationId: string;
-      response: MultipartResponse;
     }
   | {
       name: typeof EXPLORER_SUBSCRIPTION_RESPONSE;
@@ -225,15 +223,13 @@ export function executeOperation({
               message: {
                 // Include the same operation ID in the response message's name
                 // so the Explorer knows which operation it's associated with
-                name: EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
+                name: EXPLORER_QUERY_MUTATION_RESPONSE,
                 operationId,
                 response: {
-                  data: {
-                    data: data.data.data,
-                    errors: data.data.errors,
-                    extensions: data.data.extensions,
-                    path: data.data.path,
-                  },
+                  data: data.data.data,
+                  errors: data.data.errors,
+                  extensions: data.data.extensions,
+                  path: data.data.path,
                   status: response.status,
                   headers: responseHeaders,
                   hasNext: true,
@@ -249,13 +245,11 @@ export function executeOperation({
               message: {
                 // Include the same operation ID in the response message's name
                 // so the Explorer knows which operation it's associated with
-                name: EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
+                name: EXPLORER_QUERY_MUTATION_RESPONSE,
                 operationId,
                 response: {
-                  data: {
-                    data: null,
-                    error: { message: err },
-                  },
+                  data: null,
+                  error: { message: err },
                   size: 0,
                   hasNext: false,
                 },
@@ -269,10 +263,10 @@ export function executeOperation({
               message: {
                 // Include the same operation ID in the response message's name
                 // so the Explorer knows which operation it's associated with
-                name: EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
+                name: EXPLORER_QUERY_MUTATION_RESPONSE,
                 operationId,
                 response: {
-                  data: { data: null },
+                  data: null,
                   size: 0,
                   status: response.status,
                   headers: responseHeaders,

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -249,7 +249,10 @@ export function executeOperation({
                 operationId,
                 response: {
                   data: null,
-                  error: { message: err },
+                  error: {
+                    message: err.message,
+                    ...(err.stack ? { stack: err.stack } : {}),
+                  },
                   size: 0,
                   hasNext: false,
                 },

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -16,7 +16,6 @@ import {
   EXPLORER_SUBSCRIPTION_RESPONSE,
   EXPLORER_SET_SOCKET_ERROR,
   EXPLORER_SET_SOCKET_STATUS,
-  TRACE_KEY,
   EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
 } from './constants';
 import {
@@ -61,7 +60,7 @@ export function sendPostMessageToEmbed({
   embeddedIFrameElement?.contentWindow?.postMessage(message, embedUrl);
 }
 
-type ResponseError = {
+export type ResponseError = {
   message: string;
   stack?: string;
 };
@@ -102,17 +101,7 @@ export type OutgoingEmbedMessage =
   | {
       name: typeof EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE;
       operationId: string;
-      response: {
-        data?: JSONValue | Record<string, unknown> | unknown[];
-        error?: ResponseError;
-        errors?: ResponseError[];
-        status?: number;
-        headers?: Record<string, string>;
-        hasNext?: boolean;
-        extensions?: { [TRACE_KEY]?: string };
-        path?: Array<string | number>;
-        size?: number;
-      };
+      response: MultipartResponse;
     }
   | {
       name: typeof EXPLORER_SUBSCRIPTION_RESPONSE;
@@ -239,13 +228,15 @@ export function executeOperation({
                 name: EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
                 operationId,
                 response: {
-                  data: data.data.data,
-                  errors: data.data.errors,
+                  data: {
+                    data: data.data.data,
+                    errors: data.data.errors,
+                    extensions: data.data.extensions,
+                    path: data.data.path,
+                  },
                   status: response.status,
                   headers: responseHeaders,
                   hasNext: true,
-                  extensions: data.data.extensions,
-                  path: data.data.path,
                   size: data.size,
                 },
               },
@@ -261,7 +252,11 @@ export function executeOperation({
                 name: EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
                 operationId,
                 response: {
-                  error: { message: err },
+                  data: {
+                    data: null,
+                    error: { message: err },
+                  },
+                  size: 0,
                   hasNext: false,
                 },
               },
@@ -277,6 +272,8 @@ export function executeOperation({
                 name: EXPLORER_QUERY_MUTATION_PARTIAL_RESPONSE,
                 operationId,
                 response: {
+                  data: { data: null },
+                  size: 0,
                   status: response.status,
                   headers: responseHeaders,
                   hasNext: false,

--- a/packages/sandbox/src/helpers/readMultipartWebStream.ts
+++ b/packages/sandbox/src/helpers/readMultipartWebStream.ts
@@ -1,15 +1,21 @@
 import type { Observer } from 'zen-observable-ts';
 import type { GraphQLError } from 'graphql';
+import type { JSONValue } from './types';
+import type { ResponseError } from './postMessageRelayHelpers';
 
 const TRACE_KEY = 'ftv1';
 export interface MultipartResponse {
   data: {
     path?: Array<string | number>;
-    data: Array<unknown> | Record<string, unknown>;
+    data: Array<unknown> | Record<string, unknown> | JSONValue | unknown[];
     errors?: Array<GraphQLError>;
+    error?: ResponseError;
     extensions?: { [TRACE_KEY]?: string };
   };
   size: number;
+  status?: number;
+  headers?: Record<string, string>;
+  hasNext?: boolean;
 }
 
 export function readMultipartWebStream(

--- a/packages/sandbox/src/helpers/readMultipartWebStream.ts
+++ b/packages/sandbox/src/helpers/readMultipartWebStream.ts
@@ -1,0 +1,142 @@
+import type { Observer } from 'zen-observable-ts';
+import type { GraphQLError } from 'graphql';
+
+const TRACE_KEY = 'ftv1';
+export interface MultipartResponse {
+  data: {
+    path?: Array<string | number>;
+    data: Array<unknown> | Record<string, unknown>;
+    errors?: Array<GraphQLError>;
+    extensions?: { [TRACE_KEY]?: string };
+  };
+  size: number;
+}
+
+export function readMultipartWebStream(
+  response: Response,
+  contentType: string,
+  observer: Observer<MultipartResponse>
+) {
+  if (response.body === null) {
+    throw new Error('Missing body');
+  } else if (typeof response.body.tee !== 'function') {
+    // not sure if we actually need this check in explorer?
+    throw new Error(
+      'Streaming bodies not supported by provided fetch implementation'
+    );
+  }
+
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+
+  // TODO: better parsing of boundary attribute?
+  const messageBoundary = `--${(
+    contentType.split('boundary=')[1] || '-'
+  ).replace(/(^('|"))|(('|")$)/g, '')}`;
+  // TODO: End message boundary???
+  const reader = response.body.getReader();
+  function readMultipartStream() {
+    reader
+      .read()
+      .then((iteration) => {
+        if (iteration.done) {
+          observer.complete?.();
+          return;
+        }
+
+        const chunk = decoder.decode(iteration.value);
+        buffer += chunk;
+
+        // buffer index
+        let bi = buffer.indexOf(messageBoundary);
+        while (bi > -1) {
+          const message = buffer.slice(0, bi);
+          buffer = buffer.slice(bi + messageBoundary.length);
+
+          if (message.trim()) {
+            const i = message.indexOf('\r\n\r\n');
+
+            // make sure header content type is valid
+            message
+              .slice(0, i)
+              .split('\n')
+              .forEach((line) => {
+                const indexOfColon = line.indexOf(':');
+                if (
+                  indexOfColon > -1 &&
+                  line.slice(0, indexOfColon).trim().toLowerCase() ===
+                    'content-type'
+                ) {
+                  if (
+                    line.slice(indexOfColon + 1).indexOf('application/json') ===
+                    -1
+                  ) {
+                    throw new Error('Unsupported patch content type'); // TODO: handle this case
+                  }
+                }
+              });
+
+            const bodyText = message.slice(i);
+            try {
+              observer.next?.({
+                data: JSON.parse(bodyText),
+                size: chunk.length,
+              });
+            } catch (err) {
+              // const parseError = err as ServerParseError;
+              // parseError.name = 'ServerParseError';
+              // parseError.response = response;
+              // parseError.statusCode = response.status;
+              // parseError.bodyText = bodyText;
+              throw err;
+            }
+          }
+
+          bi = buffer.indexOf(messageBoundary);
+        }
+
+        readMultipartStream();
+      })
+      .catch((err) => {
+        if (err.name === 'AbortError') return;
+        // if it is a network error, BUT there is graphql result info fire
+        // the next observer before calling error this gives apollo-client
+        // (and react-apollo) the `graphqlErrors` and `networkErrors` to
+        // pass to UI this should only happen if we *also* have data as
+        // part of the response key per the spec
+        if (err.result && err.result.errors && err.result.data) {
+          // if we don't call next, the UI can only show networkError
+          // because AC didn't get any graphqlErrors this is graphql
+          // execution result info (i.e errors and possibly data) this is
+          // because there is no formal spec how errors should translate to
+          // http status codes. So an auth error (401) could have both data
+          // from a public field, errors from a private field, and a status
+          // of 401
+          // {
+          //  user { // this will have errors
+          //    firstName
+          //  }
+          //  products { // this is public so will have data
+          //    cost
+          //  }
+          // }
+          //
+          // the result of above *could* look like this:
+          // {
+          //   data: { products: [{ cost: "$10" }] },
+          //   errors: [{
+          //      message: 'your session has timed out',
+          //      path: []
+          //   }]
+          // }
+          // status code of above would be a 401
+          // in the UI you want to show data where you can, errors as data where you can
+          // and use correct http status codes
+          observer.next?.({ data: err.result, size: Infinity });
+        }
+
+        observer.error?.(err);
+      });
+  }
+  readMultipartStream();
+}

--- a/packages/sandbox/src/helpers/readMultipartWebStream.ts
+++ b/packages/sandbox/src/helpers/readMultipartWebStream.ts
@@ -2,12 +2,12 @@ import type { Observer } from 'zen-observable-ts';
 import type { GraphQLError } from 'graphql';
 import type { JSONValue } from './types';
 import type { ResponseError } from './postMessageRelayHelpers';
+import type { TRACE_KEY } from './constants';
 
-const TRACE_KEY = 'ftv1';
 export interface MultipartResponse {
   data: {
     path?: Array<string | number>;
-    data: Array<unknown> | Record<string, unknown> | JSONValue | unknown[];
+    data: Record<string, unknown> | JSONValue;
     errors?: Array<GraphQLError>;
     error?: ResponseError;
     extensions?: { [TRACE_KEY]?: string };


### PR DESCRIPTION
<!--
Please look through this checklist to see if there may be relevant actions to take before requesting reviewers:

https://apollographql.quip.com/six7ABVVjsB5#YIYABAGM2oX
-->

## Context
[JIRA](https://apollographql.atlassian.net/browse/NEBULA-1271)
[Related studio-ui PR](https://github.com/mdg-private/studio-ui/pull/6647)

## What changed
- Added support for `@defer` and `@stream` in embedded Explorer and embedded Sandbox
- Added `EXPLORER_PARTIAL_RESPONSE` listener to send PMs to studio when observing a multipart response


## How to test this PR
- Checkout to `william/embedded-defer` in the `embeddable-explorer` repo
- Checkout to `william/defer/embedded-defer` in `studio-ui`
- Add `__testLocal__: true,` in `localDevelopmentExample.html`
- `npm run start:embedded` on `studio-ui`
- `cd packages/sandbox && npm run build:umd` on `embeddable-explorer`
- `cd packages/explorer && npm run build:umd` on `embeddable-explorer`

```
git clone git@github.com:contra/graphql-helix.git
cd graphql-helix
yarn
npm i cors
npm i --save-dev @types/cors
```
Then add these lines to `examples/express/server.ts`:
```
import cors from "cors";
app.use(cors());
```

```
npm run build
cd examples/express
npm start
```

Then test out @defer and @stream
Example query:
```
fragment Test on Song {
  firstVerse
  secondVerse
}
query Q {
  song {
    ...Test @defer
  }
  alphabet @stream
}
```


https://user-images.githubusercontent.com/16390269/181305363-565bb40d-0eab-4d3b-8e24-cb5954653a72.mov