### PR TITLE
Allow passing initialRequestQueryPlan

### DIFF
--- a/.changeset/unlucky-books-add.md
+++ b/.changeset/unlucky-books-add.md
@@ -1,0 +1,5 @@
+---
+'@apollo/sandbox': patch
+---
+
+Addded internal query plan initial value type and param

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -18,7 +18,6 @@ export interface EmbeddableSandboxOptions {
   initialEndpoint?: string;
 
   initialState?: {
-    requestQueryPlan?: boolean;
     document?: string;
     variables?: JSONObject;
     headers?: Record<string, string>;
@@ -32,6 +31,7 @@ export interface EmbeddableSandboxOptions {
 
 type InternalEmbeddableSandboxOptions = EmbeddableSandboxOptions & {
   __testLocal__?: boolean;
+  initialRequestQueryPlan?: boolean;
 };
 
 let idCounter = 0;
@@ -92,8 +92,7 @@ export class EmbeddedSandbox {
       parentSupportsSubscriptions: true,
       version: packageJSON.version,
       runTelemetry: true,
-      initialRequestQueryPlan:
-        this.options.initialState?.requestQueryPlan ?? false,
+      initialRequestQueryPlan: this.options.initialRequestQueryPlan ?? false,
     };
 
     const queryString = Object.entries(queryParams)

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -14,7 +14,7 @@ import packageJSON from '../package.json';
 import type { JSONObject } from './helpers/types';
 
 export interface EmbeddableSandboxOptions {
-  target: string | HTMLElement; // HTMLElement is to accomodate people who might prefer to pass in a ref
+  target: string | HTMLElement; // HTMLElement is to accommodate people who might prefer to pass in a ref
   initialEndpoint?: string;
 
   initialState?: {

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -18,6 +18,7 @@ export interface EmbeddableSandboxOptions {
   initialEndpoint?: string;
 
   initialState?: {
+    requestQueryPlan?: boolean;
     document?: string;
     variables?: JSONObject;
     headers?: Record<string, string>;
@@ -91,6 +92,8 @@ export class EmbeddedSandbox {
       parentSupportsSubscriptions: true,
       version: packageJSON.version,
       runTelemetry: true,
+      initialRequestQueryPlan:
+        this.options.initialState?.requestQueryPlan ?? false,
     };
 
     const queryString = Object.entries(queryParams)


### PR DESCRIPTION
In prep for up coming toggle to send a header to router that will make it return the query plan, we want to allow embed to pass the initial value for the request query plan toggle. This way, routers internal sandbox embed can make this default to true.

This corresponds with https://github.com/mdg-private/studio-ui/pull/6986  which is the PR that reads this value
https://apollographql.atlassian.net/browse/NEBULA-1604