### PR TITLE
Update GraphQL to 16 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-react": "^7.29.4",
         "eslint-plugin-react-hooks": "4.5.0",
         "fs-extra": "^10.1.0",
-        "graphql": "15.8.0",
+        "graphql": "16.6.0",
         "husky": "7.0.4",
         "prettier": "2.6.2",
         "react": "18.1.0",
@@ -4927,10 +4927,11 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "15.8.0",
-      "license": "MIT",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "engines": {
-        "node": ">= 10.x"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-ws": {
@@ -13347,7 +13348,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.8.0"
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
     "graphql-ws": {
       "version": "5.9.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "4.5.0",
     "fs-extra": "^10.1.0",
-    "graphql": "15.8.0",
+    "graphql": "16.6.0",
     "husky": "7.0.4",
     "prettier": "2.6.2",
     "react": "18.1.0",

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -20,7 +20,8 @@ import {
 } from './constants';
 import MIMEType from 'whatwg-mimetype';
 import { readMultipartWebStream } from './readMultipartWebStream';
-import type { JSONObject, JSONValue } from './types';
+import type { JSONValue } from './types';
+import type { ObjMap } from 'graphql/jsutils/ObjMap';
 
 export type HandleRequest = (
   endpointUrl: string,
@@ -63,7 +64,7 @@ export type ResponseError = {
 export type SocketStatus = 'disconnected' | 'connecting' | 'connected';
 
 interface ResponseData {
-  data?: Record<string, unknown> | JSONValue;
+  data?: Record<string, unknown> | JSONValue | ObjMap<unknown>;
   path?: Array<string | number>;
   errors?: Array<GraphQLError>;
   extensions?: { [TRACE_KEY]?: string };
@@ -114,7 +115,7 @@ export type OutgoingEmbedMessage =
       name: typeof EXPLORER_SUBSCRIPTION_RESPONSE;
       operationId: string;
       response: {
-        data?: ExecutionResult<JSONObject>;
+        data?: ExecutionResult<ObjMap<unknown>> | ExecutionResult<JSONValue>;
         error?: Error;
         errors?: [Error];
       };

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -115,7 +115,7 @@ export type OutgoingEmbedMessage =
       name: typeof EXPLORER_SUBSCRIPTION_RESPONSE;
       operationId: string;
       response: {
-        data?: ExecutionResult<ObjMap<unknown>> | ExecutionResult<JSONValue>;
+        data?: ExecutionResult<JSONValue | ObjMap<unknown>>;
         error?: Error;
         errors?: [Error];
       };

--- a/packages/explorer/src/helpers/subscriptionPostMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/subscriptionPostMessageRelayHelpers.ts
@@ -16,6 +16,7 @@ import {
   sendPostMessageToEmbed,
   SocketStatus,
 } from './postMessageRelayHelpers';
+import type { ObjMap } from 'graphql/jsutils/ObjMap';
 
 export type GraphQLSubscriptionLibrary =
   | 'subscriptions-transport-ws'
@@ -137,13 +138,17 @@ class SubscriptionClient {
     }
   ) {
     return {
-      subscribe: (subscribeParams: Observer<ExecutionResult<JSONObject>>) => {
+      subscribe: (
+        subscribeParams: Observer<ExecutionResult<ObjMap<unknown>>>
+      ) => {
         if (this.protocol === 'graphql-ws') {
           this.unsubscribeFunctions.push(
             this.graphWsClient.subscribe(params, {
               ...subscribeParams,
               next: (data) =>
-                subscribeParams.next?.(data as ExecutionResult<JSONObject>),
+                subscribeParams.next?.(
+                  data as ExecutionResult<ObjMap<unknown>>
+                ),
               error: (error) => subscribeParams.error?.(error as Error),
               complete: () => {},
             })

--- a/packages/explorer/src/helpers/subscriptionPostMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/subscriptionPostMessageRelayHelpers.ts
@@ -5,7 +5,7 @@ import {
   OperationOptions,
   SubscriptionClient as TransportSubscriptionClient,
 } from 'subscriptions-transport-ws';
-import type { JSONObject } from './types';
+import type { JSONObject, JSONValue } from './types';
 import {
   EXPLORER_SET_SOCKET_STATUS,
   EXPLORER_SET_SOCKET_ERROR,
@@ -139,7 +139,7 @@ class SubscriptionClient {
   ) {
     return {
       subscribe: (
-        subscribeParams: Observer<ExecutionResult<ObjMap<unknown>>>
+        subscribeParams: Observer<ExecutionResult<ObjMap<unknown> | JSONValue>>
       ) => {
         if (this.protocol === 'graphql-ws') {
           this.unsubscribeFunctions.push(
@@ -147,7 +147,7 @@ class SubscriptionClient {
               ...subscribeParams,
               next: (data) =>
                 subscribeParams.next?.(
-                  data as ExecutionResult<ObjMap<unknown>>
+                  data as ExecutionResult<ObjMap<unknown> | JSONValue>
                 ),
               error: (error) => subscribeParams.error?.(error as Error),
               complete: () => {},

--- a/packages/sandbox/package-lock.json
+++ b/packages/sandbox/package-lock.json
@@ -1,0 +1,189 @@
+{
+  "name": "@apollo/sandbox",
+  "version": "0.3.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@apollo/sandbox",
+      "version": "0.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/whatwg-mimetype": "^3.0.0",
+        "graphql-ws": "^5.9.0",
+        "subscriptions-transport-ws": "^0.11.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0",
+        "npm": ">=7.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-xHFOhd41VpUR6Y0k8ZinlyFv5cyhC/r2zghJgWWN8oNxqNo45Nf0qCBInJsFeifLeoHcIF4voEfap4A2GYHWkw=="
+    },
+    "node_modules/backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA=="
+    },
+    "node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "node_modules/graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.2.tgz",
+      "integrity": "sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+    },
+    "node_modules/subscriptions-transport-ws": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
+      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
+      "dependencies": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.7.2 || ^16.0.0"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "@types/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-xHFOhd41VpUR6Y0k8ZinlyFv5cyhC/r2zghJgWWN8oNxqNo45Nf0qCBInJsFeifLeoHcIF4voEfap4A2GYHWkw=="
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA=="
+    },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "peer": true
+    },
+    "graphql-ws": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.11.2.tgz",
+      "integrity": "sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==",
+      "requires": {}
+    },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+    },
+    "subscriptions-transport-ws": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
+      "requires": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
+    "whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
+    },
+    "ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "requires": {}
+    }
+  }
+}

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -20,7 +20,8 @@ import {
 } from './constants';
 import MIMEType from 'whatwg-mimetype';
 import { readMultipartWebStream } from './readMultipartWebStream';
-import type { JSONObject, JSONValue } from './types';
+import type { JSONValue } from './types';
+import type { ObjMap } from 'graphql/jsutils/ObjMap';
 
 export type HandleRequest = (
   endpointUrl: string,
@@ -63,7 +64,7 @@ export type ResponseError = {
 };
 
 interface ResponseData {
-  data?: Record<string, unknown> | JSONValue;
+  data?: Record<string, unknown> | JSONValue | ObjMap<unknown>;
   path?: Array<string | number>;
   errors?: Array<GraphQLError>;
   extensions?: { [TRACE_KEY]?: string };
@@ -114,7 +115,7 @@ export type OutgoingEmbedMessage =
       name: typeof EXPLORER_SUBSCRIPTION_RESPONSE;
       operationId: string;
       response: {
-        data?: ExecutionResult<JSONObject>;
+        data?: ExecutionResult<ObjMap<unknown>> | ExecutionResult<JSONValue>;
         error?: Error;
         errors?: [Error];
       };

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -115,7 +115,7 @@ export type OutgoingEmbedMessage =
       name: typeof EXPLORER_SUBSCRIPTION_RESPONSE;
       operationId: string;
       response: {
-        data?: ExecutionResult<ObjMap<unknown>> | ExecutionResult<JSONValue>;
+        data?: ExecutionResult<JSONValue | ObjMap<unknown>>;
         error?: Error;
         errors?: [Error];
       };

--- a/packages/sandbox/src/helpers/subscriptionPostMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/subscriptionPostMessageRelayHelpers.ts
@@ -16,6 +16,7 @@ import {
   sendPostMessageToEmbed,
   SocketStatus,
 } from './postMessageRelayHelpers';
+import type { ObjMap } from 'graphql/jsutils/ObjMap';
 
 export type GraphQLSubscriptionLibrary =
   | 'subscriptions-transport-ws'
@@ -137,13 +138,17 @@ class SubscriptionClient {
     }
   ) {
     return {
-      subscribe: (subscribeParams: Observer<ExecutionResult<JSONObject>>) => {
+      subscribe: (
+        subscribeParams: Observer<ExecutionResult<ObjMap<unknown>>>
+      ) => {
         if (this.protocol === 'graphql-ws') {
           this.unsubscribeFunctions.push(
             this.graphWsClient.subscribe(params, {
               ...subscribeParams,
               next: (data) =>
-                subscribeParams.next?.(data as ExecutionResult<JSONObject>),
+                subscribeParams.next?.(
+                  data as ExecutionResult<ObjMap<unknown>>
+                ),
               error: (error) => subscribeParams.error?.(error as Error),
               complete: () => {},
             })

--- a/packages/sandbox/src/helpers/subscriptionPostMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/subscriptionPostMessageRelayHelpers.ts
@@ -5,7 +5,7 @@ import {
   OperationOptions,
   SubscriptionClient as TransportSubscriptionClient,
 } from 'subscriptions-transport-ws';
-import type { JSONObject } from './types';
+import type { JSONObject, JSONValue } from './types';
 import {
   EXPLORER_SET_SOCKET_ERROR,
   EXPLORER_SET_SOCKET_STATUS,
@@ -139,7 +139,7 @@ class SubscriptionClient {
   ) {
     return {
       subscribe: (
-        subscribeParams: Observer<ExecutionResult<ObjMap<unknown>>>
+        subscribeParams: Observer<ExecutionResult<ObjMap<unknown> | JSONValue>>
       ) => {
         if (this.protocol === 'graphql-ws') {
           this.unsubscribeFunctions.push(
@@ -147,7 +147,7 @@ class SubscriptionClient {
               ...subscribeParams,
               next: (data) =>
                 subscribeParams.next?.(
-                  data as ExecutionResult<ObjMap<unknown>>
+                  data as ExecutionResult<ObjMap<unknown> | JSONValue>
                 ),
               error: (error) => subscribeParams.error?.(error as Error),
               complete: () => {},


### PR DESCRIPTION
this PR 
- updated graphql-js to version 16.X
- changes the types of some of the subscription data to be aligned with typescript. 

subscription-transport-ws wants everything to by typed as `ObjMap`, which is really just an object as far as I can tell:

```
export interface ObjMap<T> {
  [key: string]: T;
}
```

vs

```
export type JSONPrimitive = boolean | null | string | number;
export type JSONObject = { [key in string]?: JSONValue };
export type JSONValue = JSONPrimitive | JSONValue[] | JSONObject;
```

Looking for verification that this is an okay thing to do. 

**How to test**

start up embedded Sandbox & input a subscription endpoint (preferably one of each subscription-transport-ws & graphql-ws) and run a subscription & make sure it works