### PR TITLE
Merge fix to issue 176

### DIFF
--- a/.changeset/nasty-penguins-whisper.md
+++ b/.changeset/nasty-penguins-whisper.md
@@ -1,0 +1,6 @@
+---
+'@apollo/explorer': patch
+'@apollo/sandbox': patch
+---
+
+Fix issue 176, cookies are sent locally even when includeCookies is set to false

--- a/packages/explorer/src/helpers/defaultHandleRequest.ts
+++ b/packages/explorer/src/helpers/defaultHandleRequest.ts
@@ -8,7 +8,7 @@ export const defaultHandleRequest = ({
   const handleRequestWithCookiePref: HandleRequest = (endpointUrl, options) =>
     fetch(endpointUrl, {
       ...options,
-      ...(includeCookies ? { credentials: 'include' } : {}),
+      ...(includeCookies ? { credentials: 'include' } : { credentials: 'omit' }),
     });
   return handleRequestWithCookiePref;
 };

--- a/packages/sandbox/src/helpers/defaultHandleRequest.ts
+++ b/packages/sandbox/src/helpers/defaultHandleRequest.ts
@@ -8,7 +8,7 @@ export const defaultHandleRequest = ({
   const handleRequestWithCookiePref: HandleRequest = (endpointUrl, options) =>
     fetch(endpointUrl, {
       ...options,
-      ...(includeCookies ? { credentials: 'include' } : {}),
+      ...(includeCookies ? { credentials: 'include' } : { credentials: 'omit' }),
     });
   return handleRequestWithCookiePref;
 };


### PR DESCRIPTION
Fix issue 176, cookies are sent locally even when includeCookies is set to false.
https://github.com/apollographql/embeddable-explorer/issues/176

The fix sets the fetch credentials explicitly to `omit`, instead of the default `same-origin`.

