### PR TITLE
Support Generic MessageEvent type now that we are on TS4 :)

### DIFF
--- a/.changeset/plenty-shrimps-breathe.md
+++ b/.changeset/plenty-shrimps-breathe.md
@@ -1,0 +1,6 @@
+---
+"@apollo/explorer": patch
+"@apollo/sandbox": patch
+---
+
+Support Generic MessageEvent type now that we are on TS4 :)

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -17,11 +17,18 @@ import {
   EXPLORER_SET_SOCKET_ERROR,
   EXPLORER_SET_SOCKET_STATUS,
   TRACE_KEY,
+  EXPLORER_LISTENING_FOR_HANDSHAKE,
+  EXPLORER_QUERY_MUTATION_REQUEST,
+  EXPLORER_SUBSCRIPTION_REQUEST,
+  EXPLORER_SUBSCRIPTION_TERMINATION,
+  EXPLORER_LISTENING_FOR_SCHEMA,
+  INTROSPECTION_QUERY_WITH_HEADERS,
 } from './constants';
 import MIMEType from 'whatwg-mimetype';
 import { readMultipartWebStream } from './readMultipartWebStream';
 import type { JSONValue } from './types';
 import type { ObjMap } from 'graphql/jsutils/ObjMap';
+import type { GraphQLSubscriptionLibrary } from './subscriptionPostMessageRelayHelpers';
 
 export type HandleRequest = (
   endpointUrl: string,
@@ -132,57 +139,55 @@ export type OutgoingEmbedMessage =
       name: typeof PARENT_LOGOUT_SUCCESS;
     };
 
-// TODO(Maya) uncomment and switch to MessageEvent as a generic when tsdx supports Typescript V4.
-// https://github.com/jaredpalmer/tsdx/issues/926
-export type IncomingEmbedMessage = MessageEvent;
-// | MessageEvent<{
-//     name: typeof EXPLORER_LISTENING_FOR_HANDSHAKE;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_QUERY_MUTATION_REQUEST;
-//     operationName?: string;
-//     operation: string;
-//     operationId: string;
-//     variables?: Record<string, string>;
-//     headers?: Record<string, string>;
-//     endpointUrl?: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_SUBSCRIPTION_REQUEST;
-//     operationId: string;
-//     operation: string;
-//     variables?: Record<string, string>;
-//     operationName?: string;
-//     headers?: Record<string, string>;
-//     subscriptionUrl: string;
-//     protocol: GraphQLSubscriptionLibrary;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_SUBSCRIPTION_TERMINATION;
-//     operationId: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_LISTENING_FOR_SCHEMA;
-//   }>
-// | MessageEvent<{
-//     name: typeof SET_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT;
-//     localStorageKey: string;
-//     partialToken: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof TRIGGER_LOGOUT_IN_PARENT;
-//     localStorageKey: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_LISTENING_FOR_PARTIAL_TOKEN;
-//     localStorageKey?: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof INTROSPECTION_QUERY_WITH_HEADERS;
-//     introspectionRequestBody: string;
-//     introspectionRequestHeaders: Record<string, string>;
-//     sandboxEndpointUrl?: string;
-//   }>;
+export type IncomingEmbedMessage =
+  | MessageEvent<{
+      name: typeof EXPLORER_LISTENING_FOR_HANDSHAKE;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_QUERY_MUTATION_REQUEST;
+      operationName?: string;
+      operation: string;
+      operationId: string;
+      variables?: Record<string, string>;
+      headers?: Record<string, string>;
+      endpointUrl?: string;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_SUBSCRIPTION_REQUEST;
+      operationId: string;
+      operation: string;
+      variables?: Record<string, string>;
+      operationName?: string;
+      headers?: Record<string, string>;
+      subscriptionUrl: string;
+      protocol: GraphQLSubscriptionLibrary;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_SUBSCRIPTION_TERMINATION;
+      operationId: string;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_LISTENING_FOR_SCHEMA;
+    }>
+  | MessageEvent<{
+      name: typeof SET_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT;
+      localStorageKey: string;
+      partialToken: string;
+    }>
+  | MessageEvent<{
+      name: typeof TRIGGER_LOGOUT_IN_PARENT;
+      localStorageKey: string;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_LISTENING_FOR_PARTIAL_TOKEN;
+      localStorageKey?: string;
+    }>
+  | MessageEvent<{
+      name: typeof INTROSPECTION_QUERY_WITH_HEADERS;
+      introspectionRequestBody: string;
+      introspectionRequestHeaders: Record<string, string>;
+      sandboxEndpointUrl?: string;
+    }>;
 
 export function executeOperation({
   endpointUrl,

--- a/packages/explorer/src/setupEmbedRelay.ts
+++ b/packages/explorer/src/setupEmbedRelay.ts
@@ -91,17 +91,21 @@ export function setupEmbedRelay({
         data.operationId
       ) {
         // Extract the operation details from the event.data object
-        const {
-          operation,
-          operationId,
-          operationName,
-          variables,
-          headers,
-          endpointUrl: studioGraphEndpointUrl,
-        } = data;
+        const { operation, operationId, operationName, variables, headers } =
+          data;
+
         if (isQueryOrMutation) {
+          // we support the old way of using the embed when we didn't require folks to have
+          // studio graphs, which is to pass in an endpoint manually. However, we use the
+          // endpoint sent to us from studio if there is no endpoint passed in manually
+          const endpointUrlToUseInExecution = endpointUrl ?? data.endpointUrl;
+          if (!endpointUrlToUseInExecution) {
+            throw new Error(
+              'Something went wrong, we should not have gotten here. Please double check that you are passing `endpointUrl` in your config if you are using an older version of embedded Explorer'
+            );
+          }
           executeOperation({
-            endpointUrl: endpointUrl ?? studioGraphEndpointUrl,
+            endpointUrl: endpointUrlToUseInExecution,
             handleRequest,
             operation,
             operationName,

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -150,7 +150,10 @@ export type IncomingEmbedMessage =
       operationId: string;
       variables?: Record<string, string>;
       headers?: Record<string, string>;
+      // This should be deleted fall 2022. Studio has been updated to only send
+      // endpointUrl, but we kept this around for service workers
       sandboxEndpointUrl?: string;
+      endpointUrl?: string;
     }>
   | MessageEvent<{
       name: typeof EXPLORER_SUBSCRIPTION_REQUEST;

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -17,11 +17,18 @@ import {
   EXPLORER_SET_SOCKET_ERROR,
   EXPLORER_SET_SOCKET_STATUS,
   TRACE_KEY,
+  EXPLORER_LISTENING_FOR_HANDSHAKE,
+  EXPLORER_QUERY_MUTATION_REQUEST,
+  EXPLORER_SUBSCRIPTION_REQUEST,
+  EXPLORER_SUBSCRIPTION_TERMINATION,
+  EXPLORER_LISTENING_FOR_SCHEMA,
+  INTROSPECTION_QUERY_WITH_HEADERS,
 } from './constants';
 import MIMEType from 'whatwg-mimetype';
 import { readMultipartWebStream } from './readMultipartWebStream';
 import type { JSONValue } from './types';
 import type { ObjMap } from 'graphql/jsutils/ObjMap';
+import type { GraphQLSubscriptionLibrary } from './subscriptionPostMessageRelayHelpers';
 
 export type HandleRequest = (
   endpointUrl: string,
@@ -132,57 +139,55 @@ export type OutgoingEmbedMessage =
       name: typeof PARENT_LOGOUT_SUCCESS;
     };
 
-// TODO(Maya) uncomment and switch to MessageEvent as a generic when tsdx supports Typescript V4.
-// https://github.com/jaredpalmer/tsdx/issues/926
-export type IncomingEmbedMessage = MessageEvent;
-// | MessageEvent<{
-//     name: typeof EXPLORER_LISTENING_FOR_HANDSHAKE;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_QUERY_MUTATION_REQUEST;
-//     operationName?: string;
-//     operation: string;
-//     operationId: string;
-//     variables?: Record<string, string>;
-//     headers?: Record<string, string>;
-//     sandboxEndpointUrl?: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_SUBSCRIPTION_REQUEST;
-//     operationId: string;
-//     operation: string;
-//     variables?: Record<string, string>;
-//     operationName?: string;
-//     headers?: Record<string, string>;
-//     subscriptionUrl: string;
-//     protocol: GraphQLSubscriptionLibrary;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_SUBSCRIPTION_TERMINATION;
-//     operationId: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_LISTENING_FOR_SCHEMA;
-//   }>
-// | MessageEvent<{
-//     name: typeof SET_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT;
-//     localStorageKey: string;
-//     partialToken: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof TRIGGER_LOGOUT_IN_PARENT;
-//     localStorageKey: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof EXPLORER_LISTENING_FOR_PARTIAL_TOKEN;
-//     localStorageKey?: string;
-//   }>
-// | MessageEvent<{
-//     name: typeof INTROSPECTION_QUERY_WITH_HEADERS;
-//     introspectionRequestBody: string;
-//     introspectionRequestHeaders: Record<string, string>;
-//     sandboxEndpointUrl?: string;
-//   }>;
+export type IncomingEmbedMessage =
+  | MessageEvent<{
+      name: typeof EXPLORER_LISTENING_FOR_HANDSHAKE;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_QUERY_MUTATION_REQUEST;
+      operationName?: string;
+      operation: string;
+      operationId: string;
+      variables?: Record<string, string>;
+      headers?: Record<string, string>;
+      sandboxEndpointUrl?: string;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_SUBSCRIPTION_REQUEST;
+      operationId: string;
+      operation: string;
+      variables?: Record<string, string>;
+      operationName?: string;
+      headers?: Record<string, string>;
+      subscriptionUrl: string;
+      protocol: GraphQLSubscriptionLibrary;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_SUBSCRIPTION_TERMINATION;
+      operationId: string;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_LISTENING_FOR_SCHEMA;
+    }>
+  | MessageEvent<{
+      name: typeof SET_PARTIAL_AUTHENTICATION_TOKEN_FOR_PARENT;
+      localStorageKey: string;
+      partialToken: string;
+    }>
+  | MessageEvent<{
+      name: typeof TRIGGER_LOGOUT_IN_PARENT;
+      localStorageKey: string;
+    }>
+  | MessageEvent<{
+      name: typeof EXPLORER_LISTENING_FOR_PARTIAL_TOKEN;
+      localStorageKey?: string;
+    }>
+  | MessageEvent<{
+      name: typeof INTROSPECTION_QUERY_WITH_HEADERS;
+      introspectionRequestBody: string;
+      introspectionRequestHeaders: Record<string, string>;
+      sandboxEndpointUrl?: string;
+    }>;
 
 export function executeOperation({
   endpointUrl,

--- a/packages/sandbox/src/setupSandboxEmbedRelay.ts
+++ b/packages/sandbox/src/setupSandboxEmbedRelay.ts
@@ -80,21 +80,24 @@ export function setupSandboxEmbedRelay({
         data.operationId
       ) {
         // Extract the operation details from the event.data object
-        const {
-          operation,
-          operationId,
-          operationName,
-          variables,
-          headers,
-          endpointUrl,
-          // this can be deleted in Fall 2022
-          // it is just here to be backwards compatible with old
-          // studio versions (service workers)
-          sandboxEndpointUrl,
-        } = data;
-        if (isQueryOrMutation && endpointUrl) {
+        const { operation, operationId, operationName, variables, headers } =
+          data;
+        if (isQueryOrMutation) {
+          const {
+            endpointUrl,
+            // this can be deleted in Fall 2022
+            // it is just here to be backwards compatible with old
+            // studio versions (service workers)
+            sandboxEndpointUrl,
+          } = data;
+          const endpointUrlToUseInExecution = endpointUrl ?? sandboxEndpointUrl;
+          if (!endpointUrlToUseInExecution) {
+            throw new Error(
+              'Something went wrong, we should not have gotten here. The sandbox endpoint url was not sent.'
+            );
+          }
           executeOperation({
-            endpointUrl: endpointUrl ?? sandboxEndpointUrl,
+            endpointUrl: endpointUrlToUseInExecution,
             handleRequest,
             operation,
             operationName,


### PR DESCRIPTION
We [upgraded to TS4 a week ago](https://github.com/apollographql/embeddable-explorer/pull/171), so now we can use the generic MessageEvent type.

This PR includes one change that have happened in the studio <> embed communication before I commented out MessageEvent generics, which is to send `endpointUrl` instead of `sandboxEndpointUrl`