### PR TITLE
add zen-observable-ts to each package file individually, not whole project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
         "packages/explorer",
         "packages/sandbox"
       ],
-      "dependencies": {
-        "zen-observable-ts": "^1.1.0"
-      },
       "devDependencies": {
         "@babel/core": "^7.18.5",
         "@changesets/changelog-github": "0.4.4",
@@ -9880,13 +9877,14 @@
     },
     "packages/explorer": {
       "name": "@apollo/explorer",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/whatwg-mimetype": "^3.0.0",
         "graphql-ws": "^5.9.0",
         "subscriptions-transport-ws": "^0.11.0",
-        "whatwg-mimetype": "^3.0.0"
+        "whatwg-mimetype": "^3.0.0",
+        "zen-observable-ts": "^1.1.0"
       },
       "engines": {
         "node": ">=12.0",
@@ -9911,13 +9909,14 @@
     },
     "packages/sandbox": {
       "name": "@apollo/sandbox",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/whatwg-mimetype": "^3.0.0",
         "graphql-ws": "^5.9.0",
         "subscriptions-transport-ws": "^0.11.0",
-        "whatwg-mimetype": "^3.0.0"
+        "whatwg-mimetype": "^3.0.0",
+        "zen-observable-ts": "^1.1.0"
       },
       "engines": {
         "node": ">=12.0",
@@ -9952,7 +9951,8 @@
         "@types/whatwg-mimetype": "^3.0.0",
         "graphql-ws": "^5.9.0",
         "subscriptions-transport-ws": "^0.11.0",
-        "whatwg-mimetype": "^3.0.0"
+        "whatwg-mimetype": "^3.0.0",
+        "zen-observable-ts": "^1.1.0"
       }
     },
     "@apollo/sandbox": {
@@ -9961,7 +9961,8 @@
         "@types/whatwg-mimetype": "^3.0.0",
         "graphql-ws": "^5.9.0",
         "subscriptions-transport-ws": "^0.11.0",
-        "whatwg-mimetype": "^3.0.0"
+        "whatwg-mimetype": "^3.0.0",
+        "zen-observable-ts": "^1.1.0"
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -84,8 +84,5 @@
     "size-limit": "5.0.5",
     "tslib": "2.3.1",
     "typescript": "4.8.4"
-  },
-  "dependencies": {
-    "zen-observable-ts": "^1.1.0"
   }
 }

--- a/packages/explorer/package-lock.json
+++ b/packages/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@apollo/sandbox",
-  "version": "1.0.0",
+  "name": "@apollo/explorer",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@apollo/sandbox",
-      "version": "1.0.0",
+      "name": "@apollo/explorer",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/whatwg-mimetype": "^3.0.0",
@@ -21,13 +21,17 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "use-deep-compare-effect": "^1.8.1"
       },
       "peerDependenciesMeta": {
         "react": {
           "optional": true
         },
         "react-dom": {
+          "optional": true
+        },
+        "use-deep-compare-effect": {
           "optional": true
         }
       }

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -72,6 +72,7 @@
     "@types/whatwg-mimetype": "^3.0.0",
     "graphql-ws": "^5.9.0",
     "subscriptions-transport-ws": "^0.11.0",
-    "whatwg-mimetype": "^3.0.0"
+    "whatwg-mimetype": "^3.0.0",
+    "zen-observable-ts": "^1.1.0"
   }
 }

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -68,6 +68,7 @@
     "@types/whatwg-mimetype": "^3.0.0",
     "graphql-ws": "^5.9.0",
     "subscriptions-transport-ws": "^0.11.0",
-    "whatwg-mimetype": "^3.0.0"
+    "whatwg-mimetype": "^3.0.0",
+    "zen-observable-ts": "^1.1.0"
   }
 }


### PR DESCRIPTION
in response to: https://github.com/apollographql/embeddable-explorer/issues/166"

We need this dep for the sandbox & explorer packages