### PR TITLE
fix: Issue 181, use handleRequest to perform introspection queries

### DIFF
--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -346,18 +346,20 @@ export function executeIntrospectionRequest({
   introspectionRequestBody,
   embeddedIFrameElement,
   embedUrl,
+  handleRequest,
 }: {
   endpointUrl: string;
   embeddedIFrameElement: HTMLIFrameElement;
   headers?: Record<string, string>;
   introspectionRequestBody: string;
   embedUrl: string;
+  handleRequest: HandleRequest;
 }) {
   const { query, operationName } = JSON.parse(introspectionRequestBody) as {
     query: string;
     operationName: string;
   };
-  return fetch(endpointUrl, {
+  return handleRequest(endpointUrl, {
     method: 'POST',
     headers: getHeadersWithContentType(headers),
     body: JSON.stringify({

--- a/packages/sandbox/src/setupSandboxEmbedRelay.ts
+++ b/packages/sandbox/src/setupSandboxEmbedRelay.ts
@@ -64,6 +64,7 @@ export function setupSandboxEmbedRelay({
             headers: introspectionRequestHeaders,
             embeddedIFrameElement: embeddedSandboxIFrameElement,
             embedUrl,
+            handleRequest,
           });
         }
       }


### PR DESCRIPTION
instead of the fetch function

`handleRequest` handles `includeCookies` logic properly. The fetch uses the default which is `same-origin`

