### PR TITLE
🐛 Fixes Issue#160: name cjs files .cjs so they don't conflict with type:module

### DIFF
--- a/.changeset/mighty-sloths-eat.md
+++ b/.changeset/mighty-sloths-eat.md
@@ -1,0 +1,6 @@
+---
+"@apollo/explorer": patch
+"@apollo/sandbox": patch
+---
+
+🐛 Fixes Issue#160: name cjs files .cjs so they don't conflict with type:module

--- a/packages/explorer/buildHelpers/createRollupConfig.js
+++ b/packages/explorer/buildHelpers/createRollupConfig.js
@@ -91,14 +91,14 @@ function createCJS_ESMRollupConfig(options) {
           ? '[name].mjs'
           : // we only make production & development builds in cjs, so we need to name the chunks accordingly
           options.environment === 'production'
-          ? '[name].production.min.js'
-          : '[name].development.js',
+          ? '[name].production.min.cjs'
+          : '[name].development.cjs',
       // we only make production & development builds in cjs, so we need to name the chunks accordingly
       ...(options.format === 'cjs' && {
         chunkFileNames:
           options.environment === 'production'
-            ? '[name].production.min.js'
-            : '[name].development.js',
+            ? '[name].production.min.cjs'
+            : '[name].development.cjs',
       }),
     },
     external: ['use-deep-compare-effect', 'react'],

--- a/packages/sandbox/buildHelpers/createRollupConfig.js
+++ b/packages/sandbox/buildHelpers/createRollupConfig.js
@@ -91,14 +91,14 @@ function createCJS_ESMRollupConfig(options) {
           ? '[name].mjs'
           : // we only make production & development builds in cjs, so we need to name the chunks accordingly
           options.environment === 'production'
-          ? '[name].production.min.js'
-          : '[name].development.js',
+          ? '[name].production.min.cjs'
+          : '[name].development.cjs',
       // we only make production & development builds in cjs, so we need to name the chunks accordingly
       ...(options.format === 'cjs' && {
         chunkFileNames:
           options.environment === 'production'
-            ? '[name].production.min.js'
-            : '[name].development.js',
+            ? '[name].production.min.cjs'
+            : '[name].development.cjs',
       }),
     },
     external: ['use-deep-compare-effect', 'react'],


### PR DESCRIPTION
https://github.com/apollographql/embeddable-explorer/issues/160

this particular part of this error ^ is important: 
```
index.development.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
```

we were naming our intermediate cjs exports as .js instead of .cjs, and since our package.json has type: module Next.js was throwing build errors. This rollup config change should solve that. 

I confirmed it outputs .cjs files.