### PR TITLE
🧹 remove package in rollup config 'externals' that isn't installed in sandbox

### DIFF
--- a/packages/sandbox/buildHelpers/createRollupConfig.js
+++ b/packages/sandbox/buildHelpers/createRollupConfig.js
@@ -101,7 +101,7 @@ function createCJS_ESMRollupConfig(options) {
             : '[name].development.cjs',
       }),
     },
-    external: ['use-deep-compare-effect', 'react'],
+    external: ['react'],
     plugins: [
       typescript({
         tsconfig: './tsconfig.json',


### PR DESCRIPTION
I need to remember what this external thing does 