### PR TITLE
🐛 🩹 send operation ids for introspection requests 🚨 wait for nebula-2002 before merge🚨 

### DIFF
--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -1,14 +1,6 @@
-import type { IntrospectionQuery } from 'graphql';
-import {
-  EMBEDDABLE_SANDBOX_URL,
-  IFRAME_DOM_ID,
-  SCHEMA_RESPONSE,
-} from './helpers/constants';
+import { EMBEDDABLE_SANDBOX_URL, IFRAME_DOM_ID } from './helpers/constants';
 import { defaultHandleRequest } from './helpers/defaultHandleRequest';
-import {
-  HandleRequest,
-  sendPostMessageToEmbed,
-} from './helpers/postMessageRelayHelpers';
+import type { HandleRequest } from './helpers/postMessageRelayHelpers';
 import { setupSandboxEmbedRelay } from './setupSandboxEmbedRelay';
 import packageJSON from '../package.json';
 import type { JSONObject } from './helpers/types';
@@ -149,20 +141,5 @@ export class EmbeddedSandbox {
     if (!this.options.target) {
       throw new Error('"target" is required');
     }
-  }
-
-  updateSchemaInEmbed({
-    schema,
-  }: {
-    schema?: string | IntrospectionQuery | undefined;
-  }) {
-    sendPostMessageToEmbed({
-      message: {
-        name: SCHEMA_RESPONSE,
-        schema,
-      },
-      embeddedIFrameElement: this.embeddedSandboxIFrameElement,
-      embedUrl: EMBEDDABLE_SANDBOX_URL(this.__testLocal__),
-    });
   }
 }

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -152,10 +152,7 @@ export type IncomingEmbedMessage =
       operationId: string;
       variables?: Record<string, string>;
       headers?: Record<string, string>;
-      // This should be deleted fall 2022. Studio has been updated to only send
-      // endpointUrl, but we kept this around for service workers
-      sandboxEndpointUrl?: string;
-      endpointUrl?: string;
+      endpointUrl: string;
     }>
   | MessageEvent<{
       name: typeof EXPLORER_SUBSCRIPTION_REQUEST;

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -97,10 +97,12 @@ export type OutgoingEmbedMessage =
       name: typeof SCHEMA_ERROR;
       error?: string;
       errors?: Array<GraphQLError>;
+      operationId: string;
     }
   | {
       name: typeof SCHEMA_RESPONSE;
       schema: IntrospectionQuery | string | undefined;
+      operationId: string;
     }
   | {
       name: typeof HANDSHAKE_RESPONSE;
@@ -190,6 +192,7 @@ export type IncomingEmbedMessage =
       introspectionRequestBody: string;
       introspectionRequestHeaders: Record<string, string>;
       sandboxEndpointUrl?: string;
+      operationId: string;
     }>;
 
 export function executeOperation({
@@ -355,6 +358,7 @@ export function executeIntrospectionRequest({
   embeddedIFrameElement,
   embedUrl,
   handleRequest,
+  operationId,
 }: {
   endpointUrl: string;
   embeddedIFrameElement: HTMLIFrameElement;
@@ -362,6 +366,7 @@ export function executeIntrospectionRequest({
   introspectionRequestBody: string;
   embedUrl: string;
   handleRequest: HandleRequest;
+  operationId: string;
 }) {
   const { query, operationName } = JSON.parse(introspectionRequestBody) as {
     query: string;
@@ -382,6 +387,7 @@ export function executeIntrospectionRequest({
           message: {
             name: SCHEMA_ERROR,
             errors: response.errors,
+            operationId,
           },
           embeddedIFrameElement,
           embedUrl,
@@ -391,6 +397,7 @@ export function executeIntrospectionRequest({
         message: {
           name: SCHEMA_RESPONSE,
           schema: response.data,
+          operationId,
         },
         embeddedIFrameElement,
         embedUrl,
@@ -401,6 +408,7 @@ export function executeIntrospectionRequest({
         message: {
           name: SCHEMA_ERROR,
           error: error,
+          operationId,
         },
         embeddedIFrameElement,
         embedUrl,

--- a/packages/sandbox/src/setupSandboxEmbedRelay.ts
+++ b/packages/sandbox/src/setupSandboxEmbedRelay.ts
@@ -56,6 +56,7 @@ export function setupSandboxEmbedRelay({
           introspectionRequestBody,
           introspectionRequestHeaders,
           sandboxEndpointUrl,
+          operationId,
         } = data;
         if (sandboxEndpointUrl) {
           executeIntrospectionRequest({
@@ -65,6 +66,7 @@ export function setupSandboxEmbedRelay({
             embeddedIFrameElement: embeddedSandboxIFrameElement,
             embedUrl,
             handleRequest,
+            operationId,
           });
         }
       }

--- a/packages/sandbox/src/setupSandboxEmbedRelay.ts
+++ b/packages/sandbox/src/setupSandboxEmbedRelay.ts
@@ -86,21 +86,14 @@ export function setupSandboxEmbedRelay({
         const { operation, operationId, operationName, variables, headers } =
           data;
         if (isQueryOrMutation) {
-          const {
-            endpointUrl,
-            // this can be deleted in Fall 2022
-            // it is just here to be backwards compatible with old
-            // studio versions (service workers)
-            sandboxEndpointUrl,
-          } = data;
-          const endpointUrlToUseInExecution = endpointUrl ?? sandboxEndpointUrl;
-          if (!endpointUrlToUseInExecution) {
+          const { endpointUrl } = data;
+          if (!endpointUrl) {
             throw new Error(
               'Something went wrong, we should not have gotten here. The sandbox endpoint url was not sent.'
             );
           }
           executeOperation({
-            endpointUrl: endpointUrlToUseInExecution,
+            endpointUrl,
             handleRequest,
             operation,
             operationName,


### PR DESCRIPTION
[Corresponding Studio PR
](https://github.com/mdg-private/studio-ui/pull/7874)
We had an issue where studio sends of multiple introspection requests, and we need to be able to identify the different ones. We weren't sending operation ids for introspection requests, but we were for all other requests. Adding operationIds to introspection ids.