### PR TITLE
NEBULA-1859: pass through `pollForSchemaUpdates` to control auto poll

### DIFF
--- a/.changeset/famous-needles-explode.md
+++ b/.changeset/famous-needles-explode.md
@@ -1,0 +1,6 @@
+---
+'@apollo/explorer': minor
+'@apollo/sandbox': minor
+---
+
+_New features!!_: configure initial autopoll state, whether or not your sandbox endpoint is editable, the ability to embed an Apollo operation collection.

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -21,6 +21,7 @@ export interface EmbeddableSandboxOptions {
     document?: string;
     variables?: JSONObject;
     headers?: Record<string, string>;
+    // defaults to true. If false, sandbox will not poll your endpoint for your schema.
     pollForSchemaUpdates?: boolean;
   };
 

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -21,6 +21,7 @@ export interface EmbeddableSandboxOptions {
     document?: string;
     variables?: JSONObject;
     headers?: Record<string, string>;
+    pollForSchemaUpdates?: boolean;
   };
 
   // optional. defaults to `return fetch(url, fetchOptions)`
@@ -93,6 +94,8 @@ export class EmbeddedSandbox {
       version: packageJSON.version,
       runTelemetry: true,
       initialRequestQueryPlan: this.options.initialRequestQueryPlan ?? false,
+      shouldDefaultAutoupdateSchema:
+        this.options.initialState?.pollForSchemaUpdates ?? true,
     };
 
     const queryString = Object.entries(queryParams)


### PR DESCRIPTION
corresponding studio-ui PR: https://github.com/mdg-private/studio-ui/pull/7878

This PR adds an initialState option `pollForSchemaUpdates`, when false the autopoll option will be off

**🚨 MERGE STUDIO PR FIRST🚨** 

**Note**

This PR is being merged into the version branch, studio PRs can be merged into main with no change in behavior, but embedded-explorer PRs should be release all in one minor version