### PR TITLE
NEBULA-1841: pass through endpoint is editable config to embeddable sandbox

### DIFF
--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -27,6 +27,8 @@ export interface EmbeddableSandboxOptions {
   handleRequest?: HandleRequest;
   // defaults to false. If you pass `handleRequest` that will override this.
   includeCookies?: boolean;
+  // defaults to true. If false, the endpoint box at the top of sandbox will be `initialEndpoint` or `localhost:4000` permanently
+  endpointIsEditable?: boolean;
 }
 
 type InternalEmbeddableSandboxOptions = EmbeddableSandboxOptions & {
@@ -93,6 +95,7 @@ export class EmbeddedSandbox {
       version: packageJSON.version,
       runTelemetry: true,
       initialRequestQueryPlan: this.options.initialRequestQueryPlan ?? false,
+      endpointIsEditable: this.options.endpointIsEditable,
     };
 
     const queryString = Object.entries(queryParams)


### PR DESCRIPTION
corresponding studio-ui PR: https://github.com/mdg-private/studio-ui/pull/7884
This PR adds an `endpointIsEditable` option. Defaults to true, when false, endpoint in the Sandbox header is static,

**🚨 MERGE STUDIO PR FIRST🚨** 

**Note**

This PR is being merged into the version branch, studio PRs can be merged into main with no change in behavior, but embedded-explorer PRs should be release all in one minor version