### PR TITLE
fix README's links to examples

### DIFF
--- a/packages/explorer/README.md
+++ b/packages/explorer/README.md
@@ -78,8 +78,8 @@ me {
 
 ### Examples from the raw cdn hosted umd file
 
-- [Embedding a registered public graph](./src/embeddableExplorer/examples/graphRef.html)
-- [Usage by directly passing in schema](./src/embeddableExplorer/examples/manualSchema.html)
+- [Embedding a registered public graph](./src/examples/graphRef.html)
+- [Usage by directly passing in schema](./src/examples/manualSchema.html)
 
 ## Developing embedded Explorer
 


### PR DESCRIPTION
<!-- Please run `npx changeset` for PRs containing changes that should be published to npm -->

Looks like the paths changed