### PR TITLE
Support multipart subs in explorer too

### DIFF
--- a/packages/explorer/src/helpers/constants.ts
+++ b/packages/explorer/src/helpers/constants.ts
@@ -1,4 +1,3 @@
-// URL for any embedded Explorer iframe
 export const EMBEDDABLE_EXPLORER_URL = (__testLocal__ = false) =>
   __testLocal__
     ? 'https://embed.apollo.local:3000'
@@ -22,7 +21,6 @@ export const EXPLORER_SUBSCRIPTION_TERMINATION =
   'ExplorerSubscriptionTermination';
 export const EXPLORER_SET_SOCKET_ERROR = 'ExplorerSetSocketError';
 export const EXPLORER_SET_SOCKET_STATUS = 'ExplorerSetSocketStatus';
-
 export const IFRAME_DOM_ID = (uniqueId: number) => `apollo-embed-${uniqueId}`;
 
 // Message types for authentication
@@ -35,4 +33,5 @@ export const EXPLORER_LISTENING_FOR_PARTIAL_TOKEN =
   'ExplorerListeningForPartialToken';
 export const PARTIAL_AUTHENTICATION_TOKEN_RESPONSE =
   'PartialAuthenticationTokenResponse';
+export const INTROSPECTION_QUERY_WITH_HEADERS = 'IntrospectionQueryWithHeaders';
 export const PARENT_LOGOUT_SUCCESS = 'ParentLogoutSuccess';

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -126,7 +126,6 @@ export type OutgoingEmbedMessage =
   | {
       name: typeof SCHEMA_RESPONSE;
       schema: IntrospectionQuery | string | undefined;
-      operationId: string;
     }
   | {
       name: typeof HANDSHAKE_RESPONSE;

--- a/packages/explorer/src/helpers/readMultipartWebStream.ts
+++ b/packages/explorer/src/helpers/readMultipartWebStream.ts
@@ -1,15 +1,7 @@
 import { Observable } from 'zen-observable-ts';
 import type { GraphQLError } from 'graphql';
-import type { JSONValue } from './types';
-import type { TRACE_KEY } from './constants';
 import type MIMEType from 'whatwg-mimetype';
-
-interface ResponseData {
-  data: Record<string, unknown> | JSONValue | undefined;
-  path?: Array<string | number>;
-  errors?: Array<GraphQLError>;
-  extensions?: { [TRACE_KEY]?: string };
-}
+import type { ResponseData } from './postMessageRelayHelpers';
 
 export interface MultipartResponse {
   data: ResponseData & {
@@ -19,135 +11,164 @@ export interface MultipartResponse {
     error?: { message: string; stack?: string };
     hasNext?: boolean;
   };
-  headers?: Record<string, string>;
+  headers?: Record<string, string> | Record<string, string>[];
   size: number;
 }
 
+// https://apollographql.quip.com/mkWRAJfuxa7L/Multipart-subscriptions-protocol-spec
+export interface MultipartSubscriptionResponse {
+  data: {
+    errors?: Array<GraphQLError>;
+    payload:
+      | (ResponseData & {
+          error?: { message: string; stack?: string };
+        })
+      | null;
+  };
+  headers?: Record<string, string> | Record<string, string>[];
+  size: number;
+  // True if --graphql-- message boundary is in the response
+  shouldTerminate?: boolean;
+}
+
 export function readMultipartWebStream(response: Response, mimeType: MIMEType) {
-  return new Observable<MultipartResponse>((observer) => {
-    if (response.body === null) {
-      throw new Error('Missing body');
-    } else if (typeof response.body.tee !== 'function') {
-      // not sure if we actually need this check in explorer?
-      throw new Error(
-        'Streaming bodies not supported by provided fetch implementation'
-      );
-    }
+  if (response.body === null) {
+    throw new Error('Missing body');
+  } else if (typeof response.body.tee !== 'function') {
+    // not sure if we actually need this check in explorer?
+    throw new Error(
+      'Streaming bodies not supported by provided fetch implementation'
+    );
+  }
 
-    const decoder = new TextDecoder('utf-8');
-    let buffer = '';
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
 
-    const messageBoundary = `--${mimeType.parameters.get('boundary') || '-'}`;
+  const messageBoundary = `--${mimeType.parameters.get('boundary') || '-'}`;
+  const subscriptionTerminationMessageBoundary = '--graphql--';
 
-    const reader = response.body.getReader();
-    function readMultipartStream() {
-      reader
-        .read()
-        .then((iteration) => {
-          if (iteration.done) {
-            observer.complete?.();
-            return;
-          }
-
-          const chunk = decoder.decode(iteration.value);
-          buffer += chunk;
-
-          let boundaryIndex = buffer.indexOf(messageBoundary);
-          while (boundaryIndex > -1) {
-            const message = buffer.slice(0, boundaryIndex);
-            buffer = buffer.slice(boundaryIndex + messageBoundary.length);
-
-            if (message.trim()) {
-              const messageStartIndex = message.indexOf('\r\n\r\n');
-
-              const chunkHeaders = Object.fromEntries(
-                message
-                  .slice(0, messageStartIndex)
-                  .split('\n')
-                  .map((line) => {
-                    const i = line.indexOf(':');
-                    if (i > -1) {
-                      const name = line.slice(0, i).trim();
-                      const value = line.slice(i + 1).trim();
-                      return [name, value] as const;
-                    } else {
-                      return null;
-                    }
-                  })
-                  .filter((h): h is NonNullable<typeof h> => !!h)
-              );
-
-              if (
-                chunkHeaders['content-type']
-                  ?.toLowerCase()
-                  .indexOf('application/json') === -1
-              ) {
-                throw new Error('Unsupported patch content type');
-              }
-
-              const bodyText = message.slice(messageStartIndex);
-              try {
-                observer.next?.({
-                  data: JSON.parse(bodyText),
-                  headers: chunkHeaders,
-                  size: chunk.length,
-                });
-              } catch (err) {
-                // const parseError = err as ServerParseError;
-                // parseError.name = 'ServerParseError';
-                // parseError.response = response;
-                // parseError.statusCode = response.status;
-                // parseError.bodyText = bodyText;
-                throw err;
-              }
+  const reader = response.body.getReader();
+  return {
+    closeReadableStream: () => reader.cancel(),
+    observable: new Observable<
+      MultipartResponse | MultipartSubscriptionResponse
+    >((observer) => {
+      function readMultipartStream() {
+        reader
+          .read()
+          .then((iteration) => {
+            if (iteration.done) {
+              observer.complete?.();
+              return;
             }
 
-            boundaryIndex = buffer.indexOf(messageBoundary);
-          }
+            const chunk = decoder.decode(iteration.value);
+            buffer += chunk;
 
-          readMultipartStream();
-        })
-        .catch((err) => {
-          if (err.name === 'AbortError') return;
-          // if it is a network error, BUT there is graphql result info fire
-          // the next observer before calling error this gives apollo-client
-          // (and react-apollo) the `graphqlErrors` and `networkErrors` to
-          // pass to UI this should only happen if we *also* have data as
-          // part of the response key per the spec
-          if (err.result && err.result.errors && err.result.data) {
-            // if we don't call next, the UI can only show networkError
-            // because AC didn't get any graphqlErrors this is graphql
-            // execution result info (i.e errors and possibly data) this is
-            // because there is no formal spec how errors should translate to
-            // http status codes. So an auth error (401) could have both data
-            // from a public field, errors from a private field, and a status
-            // of 401
-            // {
-            //  user { // this will have errors
-            //    firstName
-            //  }
-            //  products { // this is public so will have data
-            //    cost
-            //  }
-            // }
-            //
-            // the result of above *could* look like this:
-            // {
-            //   data: { products: [{ cost: "$10" }] },
-            //   errors: [{
-            //      message: 'your session has timed out',
-            //      path: []
-            //   }]
-            // }
-            // status code of above would be a 401
-            // in the UI you want to show data where you can, errors as data where you can
-            // and use correct http status codes
-            observer.next?.({ data: err.result, size: Infinity });
-          }
+            let boundaryIndex = buffer.indexOf(messageBoundary);
+            while (boundaryIndex > -1) {
+              const message = buffer.slice(0, boundaryIndex);
+              buffer = buffer.slice(boundaryIndex + messageBoundary.length);
 
-          observer.error?.(err);
-        });
-    }
-    readMultipartStream();
-  });
+              if (message.trim()) {
+                const messageStartIndex = message.indexOf('\r\n\r\n');
+
+                const chunkHeaders = Object.fromEntries(
+                  message
+                    .slice(0, messageStartIndex)
+                    .split('\n')
+                    .map((line) => {
+                      const i = line.indexOf(':');
+                      if (i > -1) {
+                        const name = line.slice(0, i).trim();
+                        const value = line.slice(i + 1).trim();
+                        return [name, value] as const;
+                      } else {
+                        return null;
+                      }
+                    })
+                    .filter((h): h is NonNullable<typeof h> => !!h)
+                );
+
+                if (
+                  chunkHeaders['content-type']
+                    ?.toLowerCase()
+                    .indexOf('application/json') === -1
+                ) {
+                  throw new Error('Unsupported patch content type');
+                }
+
+                const bodyText = message.slice(messageStartIndex);
+                try {
+                  observer.next?.({
+                    data: JSON.parse(bodyText),
+                    headers: chunkHeaders,
+                    size: chunk.length,
+                    ...(chunk.indexOf(subscriptionTerminationMessageBoundary) >
+                    -1
+                      ? { shouldTerminate: true }
+                      : {}),
+                  });
+                } catch (err) {
+                  // const parseError = err as ServerParseError;
+                  // parseError.name = 'ServerParseError';
+                  // parseError.response = response;
+                  // parseError.statusCode = response.status;
+                  // parseError.bodyText = bodyText;
+                  throw err;
+                }
+              }
+
+              boundaryIndex = buffer.indexOf(messageBoundary);
+            }
+
+            readMultipartStream();
+          })
+          .catch((err) => {
+            if (err.name === 'AbortError') return;
+            // if it is a network error, BUT there is graphql result info fire
+            // the next observer before calling error this gives apollo-client
+            // (and react-apollo) the `graphqlErrors` and `networkErrors` to
+            // pass to UI this should only happen if we *also* have data as
+            // part of the response key per the spec
+            if (err.result && err.result.errors && err.result.data) {
+              // if we don't call next, the UI can only show networkError
+              // because AC didn't get any graphqlErrors this is graphql
+              // execution result info (i.e errors and possibly data) this is
+              // because there is no formal spec how errors should translate to
+              // http status codes. So an auth error (401) could have both data
+              // from a public field, errors from a private field, and a status
+              // of 401
+              // {
+              //  user { // this will have errors
+              //    firstName
+              //  }
+              //  products { // this is public so will have data
+              //    cost
+              //  }
+              // }
+              //
+              // the result of above *could* look like this:
+              // {
+              //   data: { products: [{ cost: "$10" }] },
+              //   errors: [{
+              //      message: 'your session has timed out',
+              //      path: []
+              //   }]
+              // }
+              // status code of above would be a 401
+              // in the UI you want to show data where you can, errors as data where you can
+              // and use correct http status codes
+              observer.next?.({
+                data: err.result,
+                size: Infinity,
+              });
+            }
+
+            observer.error?.(err);
+          });
+      }
+      readMultipartStream();
+    }),
+  };
 }

--- a/packages/explorer/src/helpers/subscriptionPostMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/subscriptionPostMessageRelayHelpers.ts
@@ -1,3 +1,4 @@
+import EventEmitter from 'eventemitter3';
 import type { ExecutionResult } from 'graphql';
 import { Client, createClient as createGraphQLWSClient } from 'graphql-ws';
 import {
@@ -5,41 +6,55 @@ import {
   OperationOptions,
   SubscriptionClient as TransportSubscriptionClient,
 } from 'subscriptions-transport-ws';
-import type { JSONObject, JSONValue } from './types';
 import {
-  EXPLORER_SET_SOCKET_STATUS,
   EXPLORER_SET_SOCKET_ERROR,
+  EXPLORER_SET_SOCKET_STATUS,
   EXPLORER_SUBSCRIPTION_RESPONSE,
   EXPLORER_SUBSCRIPTION_TERMINATION,
 } from './constants';
 import {
+  executeOperation,
+  HandleRequest,
   sendPostMessageToEmbed,
   SocketStatus,
 } from './postMessageRelayHelpers';
-import type { ObjMap } from 'graphql/jsutils/ObjMap';
+import type { JSONObject } from './types';
 
 export type GraphQLSubscriptionLibrary =
   | 'subscriptions-transport-ws'
-  | 'graphql-ws';
+  | 'graphql-ws'
+  | 'http-multipart';
 
 // @see https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
 function assertUnreachable(x: never): never {
   throw new Error(`Didn't expect to get here ${x}`);
 }
 
-class SubscriptionClient {
-  protocol: GraphQLSubscriptionLibrary;
+type HTTPMultipartParams = {
+  includeCookies?: boolean;
+  handleRequest: HandleRequest;
+};
+
+export type HTTPMultipartClient = EventEmitter<
+  'connected' | 'error' | 'disconnected'
+> & {
+  stopListeningCallback: (() => void) | undefined;
+};
+
+class SubscriptionClient<Protocol extends GraphQLSubscriptionLibrary> {
+  protocol: Protocol;
   unsubscribeFunctions: Array<() => void> = [];
   url: string;
   headers: Record<string, string> | undefined;
   // Private variables
+  private _multipartClient: HTTPMultipartClient | undefined;
   private _graphWsClient: Client | undefined;
   private _transportSubscriptionClient: undefined | TransportSubscriptionClient;
 
   constructor(
     url: string,
     headers: Record<string, string> | undefined,
-    protocol: GraphQLSubscriptionLibrary
+    protocol: Protocol
   ) {
     this.protocol = protocol;
     this.url = url;
@@ -71,7 +86,24 @@ class SubscriptionClient {
     return client;
   }
 
+  public get multipartClient(): HTTPMultipartClient {
+    const client =
+      this._multipartClient ??
+      Object.assign(
+        new EventEmitter<'connected' | 'error' | 'disconnected'>(),
+        {
+          stopListeningCallback: undefined,
+        }
+      );
+    this._multipartClient = client;
+    return client;
+  }
+
   onConnected(callback: () => void) {
+    if (this.protocol === 'http-multipart') {
+      this.multipartClient.on('connected', callback);
+      return () => this.multipartClient.off('connected', callback);
+    }
     if (this.protocol === 'graphql-ws') {
       return this.graphWsClient.on('connected', callback);
     }
@@ -81,6 +113,9 @@ class SubscriptionClient {
     assertUnreachable(this.protocol);
   }
   onConnecting(callback: () => void) {
+    if (this.protocol === 'http-multipart') {
+      return;
+    }
     if (this.protocol === 'graphql-ws') {
       return this.graphWsClient.on('connecting', callback);
     }
@@ -90,6 +125,10 @@ class SubscriptionClient {
     assertUnreachable(this.protocol);
   }
   onError(callback: (e: Error) => void) {
+    if (this.protocol === 'http-multipart') {
+      this.multipartClient.on('error', callback);
+      return () => this.multipartClient.off('error', callback);
+    }
     if (this.protocol === 'graphql-ws') {
       return this.graphWsClient.on('error', (error: unknown) =>
         callback(error as Error)
@@ -103,6 +142,9 @@ class SubscriptionClient {
     assertUnreachable(this.protocol);
   }
   onReconnecting(callback: () => void) {
+    if (this.protocol === 'http-multipart') {
+      return;
+    }
     if (this.protocol === 'graphql-ws') {
       return;
     }
@@ -112,6 +154,9 @@ class SubscriptionClient {
     assertUnreachable(this.protocol);
   }
   onReconnected(callback: () => void) {
+    if (this.protocol === 'http-multipart') {
+      return;
+    }
     if (this.protocol === 'graphql-ws') {
       return;
     }
@@ -121,6 +166,10 @@ class SubscriptionClient {
     assertUnreachable(this.protocol);
   }
   onDisconnected(callback: () => void) {
+    if (this.protocol === 'http-multipart') {
+      this.multipartClient.on('disconnected', callback);
+      return () => this.multipartClient.off('disconnected', callback);
+    }
     if (this.protocol === 'graphql-ws') {
       return this.graphWsClient.on('closed', callback);
     }
@@ -129,26 +178,60 @@ class SubscriptionClient {
     }
     assertUnreachable(this.protocol);
   }
+  dispose() {
+    if (this.protocol === 'http-multipart') {
+      this.multipartClient.stopListeningCallback?.();
+      return;
+    }
+    if (this.protocol === 'graphql-ws') {
+      return this.graphWsClient.dispose();
+    }
+    if (this.protocol === 'subscriptions-transport-ws') {
+      return this.transportSubscriptionClient.close();
+    }
+    assertUnreachable(this.protocol);
+  }
 
   request(
     params: OperationOptions & {
       query: string;
-      variables: JSONObject;
+      variables: Record<string, string> | undefined;
       operationName: string | undefined;
+      httpMultipartParams?: HTTPMultipartParams;
+      embeddedIFrameElement: HTMLIFrameElement;
+      embedUrl: string;
+      operationId: string;
     }
   ) {
     return {
-      subscribe: (
-        subscribeParams: Observer<ExecutionResult<ObjMap<unknown> | JSONValue>>
+      subscribe: async (
+        subscribeParams: Observer<ExecutionResult<Record<string, unknown>>>
       ) => {
+        if (this.protocol === 'http-multipart' && params.httpMultipartParams) {
+          // we only use subscribeParams for websockets, for http multipart subs
+          // we do all responding in executeOperation, since this is where we set
+          // up the Observable
+          await executeOperation({
+            operation: params.query,
+            operationName: params.operationName,
+            variables: params.variables,
+            headers: this.headers ?? {},
+            includeCookies: params.httpMultipartParams?.includeCookies ?? false,
+            endpointUrl: this.url,
+            embeddedIFrameElement: params.embeddedIFrameElement,
+            embedUrl: params.embedUrl,
+            operationId: params.operationId,
+            handleRequest: params.httpMultipartParams?.handleRequest,
+            isMultipartSubscription: true,
+            multipartSubscriptionClient: this.multipartClient,
+          });
+        }
         if (this.protocol === 'graphql-ws') {
           this.unsubscribeFunctions.push(
             this.graphWsClient.subscribe(params, {
               ...subscribeParams,
               next: (data) =>
-                subscribeParams.next?.(
-                  data as ExecutionResult<ObjMap<unknown> | JSONValue>
-                ),
+                subscribeParams.next?.(data as Record<string, unknown>),
               error: (error) => subscribeParams.error?.(error as Error),
               complete: () => {},
             })
@@ -166,6 +249,9 @@ class SubscriptionClient {
   }
 
   unsubscribeAll() {
+    if (this.protocol === 'http-multipart') {
+      this.multipartClient.stopListeningCallback?.();
+    }
     if (this.protocol === 'graphql-ws') {
       this.unsubscribeFunctions.forEach((off) => {
         off();
@@ -179,7 +265,7 @@ class SubscriptionClient {
   }
 }
 
-export function setParentSocketError({
+function setParentSocketError({
   error,
   embeddedIFrameElement,
   embedUrl,
@@ -227,16 +313,18 @@ export function executeSubscription({
   embedUrl,
   subscriptionUrl,
   protocol,
+  httpMultipartParams,
 }: {
   operation: string;
   operationId: string;
   embeddedIFrameElement: HTMLIFrameElement;
   operationName: string | undefined;
-  variables?: JSONObject;
+  variables?: Record<string, string>;
   headers?: Record<string, string>;
   embedUrl: string;
   subscriptionUrl: string;
   protocol: GraphQLSubscriptionLibrary;
+  httpMultipartParams: HTTPMultipartParams;
 }) {
   const client = new SubscriptionClient(
     subscriptionUrl,
@@ -311,33 +399,49 @@ export function executeSubscription({
       query: operation,
       variables: variables ?? {},
       operationName,
+      embeddedIFrameElement,
+      embedUrl,
+      httpMultipartParams,
+      operationId,
     })
-    .subscribe({
-      next(data) {
-        sendPostMessageToEmbed({
-          message: {
-            // Include the same operation ID in the response message's name
-            // so the Explorer knows which operation it's associated with
-            name: EXPLORER_SUBSCRIPTION_RESPONSE,
-            operationId,
-            response: { data },
-          },
-          embeddedIFrameElement,
-          embedUrl,
-        });
-      },
-      error: (error) => {
-        sendPostMessageToEmbed({
-          message: {
-            // Include the same operation ID in the response message's name
-            // so the Explorer knows which operation it's associated with
-            name: EXPLORER_SUBSCRIPTION_RESPONSE,
-            operationId,
-            response: { error: JSON.parse(JSON.stringify(error)) },
-          },
-          embeddedIFrameElement,
-          embedUrl,
-        });
-      },
-    });
+    .subscribe(
+      // we only use these callbacks for websockets, for http multipart subs
+      // we do all responding in executeOperation, since this is where we set
+      // up the Observable
+      {
+        next(data) {
+          sendPostMessageToEmbed({
+            message: {
+              name: EXPLORER_SUBSCRIPTION_RESPONSE,
+              // Include the same operation ID in the response message's name
+              // so the Explorer knows which operation it's associated with
+              operationId,
+              // we use different versions of graphql in Explorer & here,
+              // Explorer expects an Object, which is what this is in reality
+              response: { data: data as JSONObject },
+            },
+            embeddedIFrameElement,
+            embedUrl,
+          });
+        },
+        error: (error) => {
+          sendPostMessageToEmbed({
+            message: {
+              name: EXPLORER_SUBSCRIPTION_RESPONSE,
+              // Include the same operation ID in the response message's name
+              // so the Explorer knows which operation it's associated with
+              operationId,
+              response: { error: JSON.parse(JSON.stringify(error)) },
+            },
+            embeddedIFrameElement,
+            embedUrl,
+          });
+        },
+      }
+    );
+
+  return {
+    dispose: () =>
+      window.removeEventListener('message', checkForSubscriptionTermination),
+  };
 }

--- a/packages/explorer/src/helpers/subscriptionPostMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/subscriptionPostMessageRelayHelpers.ts
@@ -265,7 +265,7 @@ class SubscriptionClient<Protocol extends GraphQLSubscriptionLibrary> {
   }
 }
 
-function setParentSocketError({
+export function setParentSocketError({
   error,
   embeddedIFrameElement,
   embedUrl,

--- a/packages/explorer/src/setupEmbedRelay.ts
+++ b/packages/explorer/src/setupEmbedRelay.ts
@@ -116,8 +116,10 @@ export function setupEmbedRelay({
             embeddedIFrameElement: embeddedExplorerIFrameElement,
             operationId,
             embedUrl,
+            isMultipartSubscription: false,
           });
         } else if (isSubscription) {
+          const { httpMultipartParams } = data;
           if (!!schema) {
             setParentSocketError({
               error: new Error(
@@ -137,6 +139,10 @@ export function setupEmbedRelay({
               embedUrl,
               subscriptionUrl: data.subscriptionUrl,
               protocol: data.protocol,
+              httpMultipartParams: {
+                ...httpMultipartParams,
+                handleRequest,
+              },
             });
           }
         }


### PR DESCRIPTION
Now that we have [autocomplete](https://github.com/mdg-private/studio-ui/pull/8332) for subscriptions, we can support subscriptions in the embedded Explorer as well as the embedded Sandbox

This PR copies the `helpers` folder from /sandbox to /explorer & does a bit of tweaking, like removing the introspection queries that we don't use in explorer, renaming from sandbox to explorer. 

It should match the changes in this [PR](https://github.com/apollographql/embeddable-explorer/pull/224) exactly, with the additions in [this PR](https://github.com/apollographql/embeddable-explorer/pull/231)