### PR TITLE
NEBULA-2242: pass through runTelemetry to studio, which now supports this

### DIFF
--- a/packages/explorer/src/EmbeddedExplorer.ts
+++ b/packages/explorer/src/EmbeddedExplorer.ts
@@ -47,6 +47,11 @@ export interface BaseEmbeddableExplorerOptions {
   persistExplorerState?: boolean;
 
   /**
+   * Whether or not to run Error tracking, Google Analytics event tracking etc
+   */
+  runTelemetry?: boolean;
+
+  /**
    * optional. defaults to `return fetch(url, fetchOptions)`
    */
   handleRequest?: HandleRequest;
@@ -215,7 +220,7 @@ export class EmbeddedExplorer {
   getEmbeddedExplorerURL = () => {
     const { displayOptions } = this.options.initialState || {};
 
-    const { persistExplorerState } = this.options;
+    const { persistExplorerState, runTelemetry } = this.options;
     const graphRef =
       'graphRef' in this.options ? this.options.graphRef : undefined;
     const queryParams = {
@@ -252,7 +257,7 @@ export class EmbeddedExplorer {
       shouldShowGlobalHeader: true,
       parentSupportsSubscriptions: !!graphRef,
       version: packageJSON.version,
-      runTelemetry: true,
+      runTelemetry: runTelemetry === undefined ? true : runTelemetry,
     };
 
     const queryString = Object.entries(queryParams)

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -43,6 +43,11 @@ export interface EmbeddableSandboxOptions {
   initialState?: InitialState;
 
   /**
+   * Whether or not to run Error tracking, Google Analytics event tracking etc
+   */
+  runTelemetry?: boolean;
+
+  /**
    * optional. defaults to `return fetch(url, fetchOptions)`
    */
   handleRequest?: HandleRequest;
@@ -112,7 +117,7 @@ export class EmbeddedSandbox {
 
   injectEmbed() {
     let element: HTMLElement | null;
-    const { target } = this.options;
+    const { target, runTelemetry } = this.options;
 
     const { includeCookies, sharedHeaders } = this.options.initialState || {};
 
@@ -150,7 +155,7 @@ export class EmbeddedSandbox {
       hideCookieToggle: this.options.hideCookieToggle ?? true,
       parentSupportsSubscriptions: true,
       version: packageJSON.version,
-      runTelemetry: true,
+      runTelemetry: runTelemetry === undefined ? true : runTelemetry,
       initialRequestQueryPlan: this.options.initialRequestQueryPlan ?? false,
       shouldDefaultAutoupdateSchema:
         this.options.initialState?.pollForSchemaUpdates ?? true,


### PR DESCRIPTION
We don't run telemetry if `runTelemetry` is false, which we used to only pass from devtools. 

We had a[ user ask if they could turn it off](https://github.com/apollographql/apollo-server/issues/7494), so this PR adds `runTelemetry` as an input option to EmbeddedExplorer & EmbeddedSandbox classes, defaulting to true. 

Here is the[ studio-ui PR](https://github.com/mdg-private/studio-ui/pull/8362) where we disabled `trackMutation` with this