### PR TITLE
pass through subscription endpoint

### DIFF
--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -40,6 +40,7 @@ type InitialState = {
 export interface EmbeddableSandboxOptions {
   target: string | HTMLElement; // HTMLElement is to accommodate people who might prefer to pass in a ref
   initialEndpoint?: string;
+  initialSubscriptionEndpoint?: string;
   initialState?: InitialState;
 
   /**
@@ -124,6 +125,7 @@ export class EmbeddedSandbox {
     const queryParams = {
       runtime: this.options.runtime,
       endpoint: this.options.initialEndpoint,
+      subscriptionEndpoint: this.options.initialSubscriptionEndpoint,
       ...(this.options.initialState &&
       'collectionId' in this.options.initialState
         ? {


### PR DESCRIPTION
<!-- Please run `npx changeset` for PRs containing changes that should be published to npm -->

https://apollograph.slack.com/archives/C026H578D6K/p1681839839729999

on the embedded Sandbox (used by router & apollo server) we specify that the endpoint url is not editable by default. The router has no config options for the users to pass, so the endpoints are not editable ever. 

This is an issue, because we don't have a way for folks to specify their subscription url at all, its just assumed that it is the ws of the endpoint url.

This PR allows passing through the subscription url explicitly. 

[See studio-ui PR accepting this query param here](https://github.com/mdg-private/studio-ui/pull/8427c)

## Test

Run embedded Sandbox locally with `npm run start:embedded -w studio`, build [this embeddable-explorer branch ](https://github.com/apollographql/embeddable-explorer/pull/250), run `localDevelopmentExample` with `endpointIsEditable` as false. Run with a certain `initialEndpoint` & `initialSubscriptionEndpoint`, then change to a different `initialEndpoint` & `initialSubscriptionEndpoint`, see in local storage that under the `sandboxConnectionSettings` for your first endpoint, the subscription url has not changed. See that the subscription url is updated for your second endpoint. 
