### PR TITLE
Add opt out option `allowDynamicStyling` for CSP enforcers

### DIFF
--- a/.changeset/quick-points-drop.md
+++ b/.changeset/quick-points-drop.md
@@ -1,0 +1,6 @@
+---
+'@apollo/explorer': minor
+'@apollo/sandbox': minor
+---
+
+Allow opting out of adding dynamic styles to the iframe rendered by Embedded Explorer / Sandbox

--- a/packages/explorer/README.md
+++ b/packages/explorer/README.md
@@ -74,6 +74,16 @@ me {
 
 }
 
+...
+// style the iframe for your site
+<style>
+  iframe {
+    height: 100%;
+    width: 100%;
+    border: none;
+  }
+</style>
+<div id="embeddableExplorer" />
 ```
 
 ### Examples from the raw cdn hosted umd file

--- a/packages/explorer/src/EmbeddedExplorer.ts
+++ b/packages/explorer/src/EmbeddedExplorer.ts
@@ -161,6 +161,7 @@ export class EmbeddedExplorer {
     iframeElement.src = this.embeddedExplorerURL;
 
     iframeElement.id = IFRAME_DOM_ID(this.uniqueEmbedInstanceId);
+    // default to `true` (`true` and `undefined` both ok)
     if (this.options.allowDynamicStyles !== false) {
       iframeElement.setAttribute(
         'style',

--- a/packages/explorer/src/EmbeddedExplorer.ts
+++ b/packages/explorer/src/EmbeddedExplorer.ts
@@ -72,6 +72,14 @@ export interface BaseEmbeddableExplorerOptions {
     accountId: string;
     inviteToken: string;
   };
+
+  /**
+   * optional. defaults to true.
+   * If false, the `width: 100%` and `height: 100%` are not applied to the iframe dynamically.
+   * You might pass false here if you enforce a Content Security Policy that disallows dynamic
+   * style injection.
+   */
+  allowDynamicStyles?: boolean;
 }
 
 interface EmbeddableExplorerOptionsWithSchema
@@ -153,11 +161,12 @@ export class EmbeddedExplorer {
     iframeElement.src = this.embeddedExplorerURL;
 
     iframeElement.id = IFRAME_DOM_ID(this.uniqueEmbedInstanceId);
-    iframeElement.setAttribute(
-      'style',
-      'height: 100%; width: 100%; border: none;'
-    );
-
+    if (this.options.allowDynamicStyles !== false) {
+      iframeElement.setAttribute(
+        'style',
+        'height: 100%; width: 100%; border: none;'
+      );
+    }
     element?.appendChild(iframeElement);
 
     // inject the Apollo favicon if there is not one on this page

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -43,6 +43,14 @@ function App() {
 
 }
 ...
+// style the iframe for your site
+<style>
+  iframe {
+    height: 100%;
+    width: 100%;
+    border: none;
+  }
+</style>
 <div id="embeddableSandbox" />
 
 ```

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -187,6 +187,7 @@ export class EmbeddedSandbox {
     )}?${queryString}`;
 
     iframeElement.id = IFRAME_DOM_ID(this.uniqueEmbedInstanceId);
+    // default to `true` (`true` and `undefined` both ok)
     if (this.options.allowDynamicStyles !== false) {
       iframeElement.setAttribute(
         'style',

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -72,6 +72,13 @@ export interface EmbeddableSandboxOptions {
    * If false, the endpoint box at the top of sandbox will be `initialEndpoint` permanently
    */
   endpointIsEditable?: boolean;
+  /**
+   * optional. defaults to true.
+   * If false, the `width: 100%` and `height: 100%` are not applied to the iframe dynamically.
+   * You might pass false here if you enforce a Content Security Policy that disallows dynamic
+   * style injection.
+   */
+  allowDynamicStyles?: boolean;
 }
 
 type InternalEmbeddableSandboxOptions = EmbeddableSandboxOptions & {
@@ -180,10 +187,12 @@ export class EmbeddedSandbox {
     )}?${queryString}`;
 
     iframeElement.id = IFRAME_DOM_ID(this.uniqueEmbedInstanceId);
-    iframeElement.setAttribute(
-      'style',
-      'height: 100%; width: 100%; border: none;'
-    );
+    if (this.options.allowDynamicStyles !== false) {
+      iframeElement.setAttribute(
+        'style',
+        'height: 100%; width: 100%; border: none;'
+      );
+    }
 
     element?.appendChild(iframeElement);
 


### PR DESCRIPTION
The dynamic style additions to the iframe were causing CSP errors for consumers. Lets not dynamically add styling for AS, which enforces a content security policy, we will style in the app there