### PR TITLE
Add wrapping error and move stacktrace to extensions

### DIFF
--- a/.changeset/tender-clouds-lie.md
+++ b/.changeset/tender-clouds-lie.md
@@ -1,0 +1,6 @@
+---
+'@apollo/explorer': patch
+'@apollo/sandbox': patch
+---
+
+Add a wrapping error message and move stacktraces to extensions

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 node_modules
 dist
+.idea

--- a/packages/explorer-helpers/src/readMultipartWebStream.ts
+++ b/packages/explorer-helpers/src/readMultipartWebStream.ts
@@ -1,14 +1,14 @@
 import { Observable } from 'zen-observable-ts';
 import type { GraphQLError } from 'graphql';
 import type MIMEType from 'whatwg-mimetype';
-import type { ResponseData } from './types';
+import type { ResponseData, ResponseError } from './types';
 
 export interface MultipartResponse {
   data: ResponseData & {
     incremental?: Array<
       ResponseData & { path: NonNullable<ResponseData['path']> }
     >;
-    error?: { message: string; stack?: string };
+    error?: ResponseError;
     hasNext?: boolean;
   };
   headers?: Record<string, string> | Record<string, string>[];
@@ -21,7 +21,7 @@ export interface MultipartSubscriptionResponse {
     errors?: Array<GraphQLError>;
     payload:
       | (ResponseData & {
-          error?: { message: string; stack?: string };
+          error?: ResponseError;
         })
       | null;
   };

--- a/packages/explorer-helpers/src/types.ts
+++ b/packages/explorer-helpers/src/types.ts
@@ -44,3 +44,10 @@ export interface ResponseData {
   errors?: Array<GraphQLError>;
   extensions?: Extensions;
 }
+
+export type ResponseError = {
+    message: string;
+    extensions?: {
+        stack?: string;
+    }
+};

--- a/packages/explorer/src/helpers/defaultHandleRequest.ts
+++ b/packages/explorer/src/helpers/defaultHandleRequest.ts
@@ -15,6 +15,9 @@ export const defaultHandleRequest = ({
         legacyIncludeCookies !== undefined
         ? { credentials: 'omit' }
         : {}),
+    }).catch((err) => {
+        err.message = `Error calling ${endpointUrl}`;
+        throw err;
     });
   return handleRequestWithCookiePref;
 };

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -72,7 +72,9 @@ export function sendPostMessageToEmbed({
 
 export type ResponseError = {
   message: string;
-  stack?: string;
+  extensions?: {
+    stack?: string;
+  }
 };
 
 export interface ResponseData {
@@ -98,7 +100,7 @@ export interface MultipartSubscriptionResponse {
     errors?: Array<GraphQLError>;
     payload:
       | (ResponseData & {
-          error?: { message: string; stack?: string };
+          error?: ResponseError;
         })
       | null;
   };
@@ -398,7 +400,7 @@ export async function executeOperation({
                 ? {
                     message: err.message,
                     ...('stack' in err && typeof err.stack === 'string'
-                      ? { stack: err.stack }
+                      ? { extensions: { stack: err.stack } }
                       : {}),
                   }
                 : undefined;

--- a/packages/explorer/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/explorer/src/helpers/postMessageRelayHelpers.ts
@@ -487,7 +487,7 @@ export async function executeOperation({
           ? {
               message: err.message,
               ...('stack' in err && typeof err.stack === 'string'
-                ? { stack: err.stack }
+                ? { extensions: { stack: err.stack } }
                 : {}),
             }
           : undefined;

--- a/packages/explorer/src/helpers/readMultipartWebStream.ts
+++ b/packages/explorer/src/helpers/readMultipartWebStream.ts
@@ -1,14 +1,14 @@
 import { Observable } from 'zen-observable-ts';
 import type { GraphQLError } from 'graphql';
 import type MIMEType from 'whatwg-mimetype';
-import type { ResponseData } from './postMessageRelayHelpers';
+import type { ResponseData, ResponseError } from './postMessageRelayHelpers';
 
 export interface MultipartResponse {
   data: ResponseData & {
     incremental?: Array<
       ResponseData & { path: NonNullable<ResponseData['path']> }
     >;
-    error?: { message: string; stack?: string };
+    error?: ResponseError;
     hasNext?: boolean;
   };
   headers?: Record<string, string> | Record<string, string>[];
@@ -21,7 +21,7 @@ export interface MultipartSubscriptionResponse {
     errors?: Array<GraphQLError>;
     payload:
       | (ResponseData & {
-          error?: { message: string; stack?: string };
+          error?: ResponseError;
         })
       | null;
   };

--- a/packages/sandbox/src/helpers/defaultHandleRequest.ts
+++ b/packages/sandbox/src/helpers/defaultHandleRequest.ts
@@ -15,6 +15,9 @@ export const defaultHandleRequest = ({
         legacyIncludeCookies !== undefined
         ? { credentials: 'omit' }
         : {}),
+    }).catch((err) => {
+        err.message = `Error calling ${endpointUrl}, ${JSON.stringify(options)}`;
+        throw err;
     });
   return handleRequestWithCookiePref;
 };

--- a/packages/sandbox/src/helpers/defaultHandleRequest.ts
+++ b/packages/sandbox/src/helpers/defaultHandleRequest.ts
@@ -16,7 +16,7 @@ export const defaultHandleRequest = ({
         ? { credentials: 'omit' }
         : {}),
     }).catch((err) => {
-        err.message = `Error calling ${endpointUrl}, ${JSON.stringify(options)}`;
+        err.message = `Error calling ${endpointUrl}`;
         throw err;
     });
   return handleRequestWithCookiePref;

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -74,7 +74,9 @@ export function sendPostMessageToEmbed({
 
 export type ResponseError = {
   message: string;
-  stack?: string;
+  extensions?: {
+    stack?: string;
+  }
 };
 
 export interface ResponseData {
@@ -100,7 +102,7 @@ export interface MultipartSubscriptionResponse {
     errors?: Array<GraphQLError>;
     payload:
       | (ResponseData & {
-          error?: { message: string; stack?: string };
+          error?: ResponseError;
         })
       | null;
   };
@@ -412,7 +414,7 @@ export async function executeOperation({
                 ? {
                     message: err.message,
                     ...('stack' in err && typeof err.stack === 'string'
-                      ? { stack: err.stack }
+                      ? { extensions: { stack: err.stack } }
                       : {}),
                   }
                 : undefined;

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -501,7 +501,7 @@ export async function executeOperation({
           ? {
               message: err.message,
               ...('stack' in err && typeof err.stack === 'string'
-                ? { stack: err.stack }
+                ? { extensions: { stack: err.stack } }
                 : {}),
             }
           : undefined;

--- a/packages/sandbox/src/helpers/readMultipartWebStream.ts
+++ b/packages/sandbox/src/helpers/readMultipartWebStream.ts
@@ -1,14 +1,14 @@
 import { Observable } from 'zen-observable-ts';
 import type { GraphQLError } from 'graphql';
 import type MIMEType from 'whatwg-mimetype';
-import type { ResponseData } from './postMessageRelayHelpers';
+import type { ResponseData, ResponseError } from './postMessageRelayHelpers';
 
 export interface MultipartResponse {
   data: ResponseData & {
     incremental?: Array<
       ResponseData & { path: NonNullable<ResponseData['path']> }
     >;
-    error?: { message: string; stack?: string };
+    error?: ResponseError;
     hasNext?: boolean;
   };
   headers?: Record<string, string> | Record<string, string>[];
@@ -21,7 +21,7 @@ export interface MultipartSubscriptionResponse {
     errors?: Array<GraphQLError>;
     payload:
       | (ResponseData & {
-          error?: { message: string; stack?: string };
+          error?: ResponseError;
         })
       | null;
   };


### PR DESCRIPTION
To provide at least a little more info, wrap the fetch function with a message to indicate that we had an issue calling the url, rather than is ambiguous `TypeError` that we get today