### PR TITLE
sendOperationHeadersInIntrospection config option, default to true

### DIFF
--- a/.changeset/twelve-hats-burn.md
+++ b/.changeset/twelve-hats-burn.md
@@ -1,0 +1,5 @@
+---
+"@apollo/sandbox": minor
+---
+
+sendOperationHeadersInIntrospection config option, default to true

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -140,7 +140,8 @@ export class EmbeddedSandbox {
       runtime: this.options.runtime,
       endpoint: this.options.initialEndpoint,
       subscriptionEndpoint: this.options.initialSubscriptionEndpoint,
-      sendOperationHeadersInIntrospection: sendOperationHeadersInIntrospection: this.options.sendOperationHeadersInIntrospection ?? true,
+      sendOperationHeadersInIntrospection:
+        this.options.sendOperationHeadersInIntrospection ?? true,
       ...(this.options.initialState &&
       'collectionId' in this.options.initialState
         ? {

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -79,6 +79,13 @@ export interface EmbeddableSandboxOptions {
    * style injection.
    */
   allowDynamicStyles?: boolean;
+  /**
+   * Defaults to true, even though our default in hosted Sandbox is false.
+   * Needed to default to true so that shipped versions particularly on Apollo Server
+   * maintain backwards compatible behavior. Pass false to exclusively pass shared headers
+   * to introspection requests.
+   */
+  sendOperationHeadersInIntrospection?: boolean;
 }
 
 type InternalEmbeddableSandboxOptions = EmbeddableSandboxOptions & {
@@ -133,6 +140,10 @@ export class EmbeddedSandbox {
       runtime: this.options.runtime,
       endpoint: this.options.initialEndpoint,
       subscriptionEndpoint: this.options.initialSubscriptionEndpoint,
+      sendOperationHeadersInIntrospection:
+        this.options.sendOperationHeadersInIntrospection == undefined
+          ? true
+          : this.options.sendOperationHeadersInIntrospection,
       ...(this.options.initialState &&
       'collectionId' in this.options.initialState
         ? {

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -140,10 +140,7 @@ export class EmbeddedSandbox {
       runtime: this.options.runtime,
       endpoint: this.options.initialEndpoint,
       subscriptionEndpoint: this.options.initialSubscriptionEndpoint,
-      sendOperationHeadersInIntrospection:
-        this.options.sendOperationHeadersInIntrospection == undefined
-          ? true
-          : this.options.sendOperationHeadersInIntrospection,
+      sendOperationHeadersInIntrospection: sendOperationHeadersInIntrospection: this.options.sendOperationHeadersInIntrospection ?? true,
       ...(this.options.initialState &&
       'collectionId' in this.options.initialState
         ? {


### PR DESCRIPTION
<!-- Please run `npx changeset` for PRs containing changes that should be published to npm -->

https://apollograph.slack.com/archives/C021CUR8WCD/p1695311045449899

We need to pass this as a config b/c AS4 defaults to `_latest` if no one passes a version, and even if we pin a version now, older versions will have changes they don't expect. So we will add a config, default it to the current behavior. Add documentation to encourage folks to make this false & update the default behavior in the hosted Sandbox