### PR TITLE
Adding support for `initialRequestConnectorsDebugging` to `EmbeddableSandbox`

### DIFF
--- a/.changeset/fuzzy-fans-invite.md
+++ b/.changeset/fuzzy-fans-invite.md
@@ -1,0 +1,5 @@
+---
+'@apollo/sandbox': minor
+---
+
+Adding support for `initialRequestConnectorsDebugging` to `EmbeddedSandbox`

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -92,6 +92,11 @@ type InternalEmbeddableSandboxOptions = EmbeddableSandboxOptions & {
   __testLocal__?: boolean;
   initialRequestQueryPlan?: boolean;
   runtime?: string;
+  /**
+   * optional. defaults to `false`.
+   * Whether or not to include the `Apollo-Connectors-Debugging: true` header in requests
+   */
+  initialRequestConnectorsDebugging?: boolean;
 };
 
 let idCounter = 0;
@@ -175,6 +180,8 @@ export class EmbeddedSandbox {
       version: packageJSON.version,
       runTelemetry: runTelemetry === undefined ? true : runTelemetry,
       initialRequestQueryPlan: this.options.initialRequestQueryPlan ?? false,
+      initialRequestConnectorsDebugging:
+        this.options.initialRequestConnectorsDebugging ?? false,
       shouldDefaultAutoupdateSchema:
         this.options.initialState?.pollForSchemaUpdates ?? true,
       endpointIsEditable: this.options.endpointIsEditable,


### PR DESCRIPTION
<!-- Please run `npx changeset` for PRs containing changes that should be published to npm -->

We have introduced a new setting config for the embedded sandbox that will allow us to automatically request connectors debugging information for display in Explorer.