### PR TITLE
Add React 19 to peer dependencies

### DIFF
--- a/.changeset/clean-houses-clap.md
+++ b/.changeset/clean-houses-clap.md
@@ -1,0 +1,5 @@
+---
+'@apollo/explorer': patch
+---
+
+Allow React 19 as peer dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -9987,7 +9987,7 @@
     },
     "packages/explorer": {
       "name": "@apollo/explorer",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@types/whatwg-mimetype": "^3.0.0",
@@ -10001,8 +10001,8 @@
         "npm": ">=7.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "use-deep-compare-effect": "^1.8.1"
       },
       "peerDependenciesMeta": {
@@ -10033,7 +10033,7 @@
     },
     "packages/sandbox": {
       "name": "@apollo/sandbox",
-      "version": "2.5.1",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "@types/whatwg-mimetype": "^3.0.0",

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -53,8 +53,8 @@
     }
   ],
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "use-deep-compare-effect": "^1.8.1"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Added React v19 to peerDependencies to prevent npm error when installing this package in an app with React 19.

<!-- Please run `npx changeset` for PRs containing changes that should be published to npm -->
