### PR TITLE
update renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,25 +1,15 @@
 {
-  extends: [
-    'config:js-lib',
-    // Our default configuration. See
-    // https://github.com/apollographql/renovate-config-apollo-open-source/blob/master/package.json
-    'apollo-open-source',
-  ],
-  schedule: null,
-  prCreation: 'immediate',
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
-    // Bunch up all non-major dependencies into a single PR.  In the common case
-    // where the upgrades apply cleanly, this causes less noise and is resolved faster
-    // than starting a bunch of upgrades in parallel for what may turn out to be
-    // a suite of related packages all released at once.
     {
-      groupName: 'all non-major dependencies',
-      matchUpdateTypes: ['patch', 'minor'],
-      groupSlug: 'all-minor-patch',
-    },
-    {
-      groupName: 'size-limit',
-      matchPackagePatterns: ['size-limit']
+      matchPackagePatterns: ["*"],
+      enabled: false,
     },
   ],
+  vulnerabilityAlerts: {
+    enabled: true,
+  },
+  lockFileMaintenance: {
+    enabled: false,
+  },
 }


### PR DESCRIPTION
<!-- Please run `npx changeset` for PRs containing changes that should be published to npm -->
Only make PRs for vulnerabilities. This removes some configuration that did grouping. We couldn't figure out how to have both before and limiting to vulnerabilities should reduce noise more then grouping.