### PR TITLE
fix cdn upload - gcloud not found error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,8 @@ jobs:
   typescript:
     executor: node
     steps:
+      - setup-explorer-gcs-creds
+      - gcp-cli/install
       - checkout
       - npm-install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 orbs:
-  gcp-cli: circleci/gcp-cli@2.4.0
+  gcp-cli: circleci/gcp-cli@3.3.0
   secops: apollo/circleci-secops-orb@2.0.6
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,8 +158,6 @@ jobs:
   typescript:
     executor: node
     steps:
-      - setup-explorer-gcs-creds
-      - gcp-cli/install
       - checkout
       - npm-install
       - run:


### PR DESCRIPTION
<!-- Please run `npx changeset` for PRs containing changes that should be published to npm -->

cdn-upload-*  tasks were failing with error of "sudo: command not found"
https://app.circleci.com/pipelines/github/apollographql/embeddable-explorer/2593/workflows/df7dff4a-77fa-47a3-90ee-f3cfa0204892/jobs/14385

updating the version seems to fix that
https://app.circleci.com/pipelines/github/apollographql/embeddable-explorer/2594/workflows/399d8353-4514-4872-b181-8f96cf4ca0d8/jobs/14389