### PR TITLE
Handle origin checks consistently

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6789,7 +6789,7 @@
     },
     "packages/explorer": {
       "name": "@apollo/explorer",
-      "version": "3.7.1",
+      "version": "3.7.3",
       "license": "MIT",
       "dependencies": {
         "@types/whatwg-mimetype": "^3.0.0",
@@ -6835,7 +6835,7 @@
     },
     "packages/sandbox": {
       "name": "@apollo/sandbox",
-      "version": "2.7.0",
+      "version": "2.7.2",
       "license": "MIT",
       "dependencies": {
         "@types/whatwg-mimetype": "^3.0.0",

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -1,6 +1,9 @@
 import { EMBEDDABLE_SANDBOX_URL, IFRAME_DOM_ID } from './helpers/constants';
 import { defaultHandleRequest } from './helpers/defaultHandleRequest';
-import type { HandleRequest } from './helpers/postMessageRelayHelpers';
+import type {
+  DisposableResource,
+  HandleRequest,
+} from './helpers/postMessageRelayHelpers';
 import { setupSandboxEmbedRelay } from './setupSandboxEmbedRelay';
 import packageJSON from '../package.json';
 import type { JSONObject } from './helpers/types';
@@ -107,7 +110,7 @@ export class EmbeddedSandbox {
   embeddedSandboxIFrameElement: HTMLIFrameElement;
   uniqueEmbedInstanceId: number;
   __testLocal__: boolean;
-  private disposable: { dispose: () => void };
+  private disposable: DisposableResource;
   constructor(options: EmbeddableSandboxOptions) {
     this.options = options as InternalEmbeddableSandboxOptions;
     this.__testLocal__ = !!this.options.__testLocal__;

--- a/packages/sandbox/src/helpers/constants.ts
+++ b/packages/sandbox/src/helpers/constants.ts
@@ -1,7 +1,5 @@
 export const EMBEDDABLE_SANDBOX_URL = (__testLocal__ = false) =>
-  __testLocal__
-    ? 'https://embed.apollo.local:3000/sandbox/explorer'
-    : 'https://sandbox.embed.apollographql.com/sandbox/explorer';
+  EMBEDDABLE_SANDBOX_URL_ORIGIN(__testLocal__) + '/sandbox/explorer';
 
 export const EMBEDDABLE_SANDBOX_URL_ORIGIN = (__testLocal__ = false) =>
   __testLocal__

--- a/packages/sandbox/src/helpers/subscriptionPostMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/subscriptionPostMessageRelayHelpers.ts
@@ -13,6 +13,8 @@ import {
   EXPLORER_SUBSCRIPTION_TERMINATION,
 } from './constants';
 import {
+  addMessageListener,
+  DisposableResource,
   executeOperation,
   HandleRequest,
   sendPostMessageToEmbed,
@@ -327,7 +329,7 @@ export function executeSubscription({
   subscriptionUrl: string;
   protocol: GraphQLSubscriptionLibrary;
   httpMultipartParams: HTTPMultipartParams;
-}) {
+}): DisposableResource {
   const client = new SubscriptionClient(
     subscriptionUrl,
     headers ?? {},
@@ -335,16 +337,16 @@ export function executeSubscription({
   );
 
   const checkForSubscriptionTermination = (event: MessageEvent) => {
-    if (
-      event.data.name === EXPLORER_SUBSCRIPTION_TERMINATION &&
-      event.origin === embedUrlOrigin
-    ) {
+    if (event.data.name === EXPLORER_SUBSCRIPTION_TERMINATION) {
       client.unsubscribeAll();
-      window.removeEventListener('message', checkForSubscriptionTermination);
+      disposeEventListener.dispose();
     }
   };
 
-  window.addEventListener('message', checkForSubscriptionTermination);
+  const disposeEventListener = addMessageListener(
+    embedUrlOrigin,
+    checkForSubscriptionTermination
+  );
 
   client.onError((e: Error) =>
     setParentSocketError({
@@ -445,8 +447,5 @@ export function executeSubscription({
       }
     );
 
-  return {
-    dispose: () =>
-      window.removeEventListener('message', checkForSubscriptionTermination),
-  };
+  return disposeEventListener;
 }

--- a/packages/sandbox/src/setupSandboxEmbedRelay.ts
+++ b/packages/sandbox/src/setupSandboxEmbedRelay.ts
@@ -8,6 +8,8 @@ import {
   INTROSPECTION_QUERY_WITH_HEADERS,
 } from './helpers/constants';
 import {
+  addMessageListener,
+  DisposableResource,
   executeIntrospectionRequest,
   executeOperation,
   handleAuthenticationPostMessage,
@@ -25,7 +27,7 @@ export function setupSandboxEmbedRelay({
   handleRequest: HandleRequest;
   embeddedSandboxIFrameElement: HTMLIFrameElement;
   __testLocal__: boolean;
-}) {
+}): DisposableResource {
   const embedUrl = EMBEDDABLE_SANDBOX_URL(__testLocal__);
   const embedUrlOrigin = EMBEDDABLE_SANDBOX_URL_ORIGIN(__testLocal__);
   // Callback definition
@@ -41,7 +43,7 @@ export function setupSandboxEmbedRelay({
     // structure of. Some have a data field that is not an object
     const data = typeof event.data === 'object' ? event.data : undefined;
 
-    if (data && 'name' in data && event.origin === embedUrlOrigin) {
+    if (data && 'name' in data) {
       // When embed connects, send a handshake message
       if (data.name === EXPLORER_LISTENING_FOR_HANDSHAKE) {
         sendPostMessageToEmbed({
@@ -136,8 +138,5 @@ export function setupSandboxEmbedRelay({
     }
   };
   // Execute our callback whenever window.postMessage is called
-  window.addEventListener('message', onPostMessageReceived);
-  return {
-    dispose: () => window.removeEventListener('message', onPostMessageReceived),
-  };
+  return addMessageListener(embedUrlOrigin, onPostMessageReceived);
 }


### PR DESCRIPTION
Adds a helper wrapper around window.addEventListener('message') which does the origin check immediately instead of at various places more nested inside the handlers.

Also don't repeat the origin when defining the URL.
