### PR TITLE
Add optional function to modify headers

### DIFF
--- a/.changeset/heavy-apples-hug.md
+++ b/.changeset/heavy-apples-hug.md
@@ -1,0 +1,5 @@
+---
+'@apollo/sandbox': minor
+---
+
+Adding support for optional `modifyHeaders` function which can modify the headers before sending the request

--- a/packages/sandbox/src/EmbeddedSandbox.ts
+++ b/packages/sandbox/src/EmbeddedSandbox.ts
@@ -6,6 +6,7 @@ import { defaultHandleRequest } from './helpers/defaultHandleRequest';
 import type {
   DisposableResource,
   HandleRequest,
+  ModifyHeaders,
 } from './helpers/postMessageRelayHelpers';
 import { setupSandboxEmbedRelay } from './setupSandboxEmbedRelay';
 import packageJSON from '../package.json';
@@ -58,6 +59,11 @@ export interface EmbeddableSandboxOptions {
    * optional. defaults to `return fetch(url, fetchOptions)`
    */
   handleRequest?: HandleRequest;
+
+  /**
+    * optional. Function that accepts the original headers and returns the modified headers.
+    */
+  modifyHeaders?: ModifyHeaders;
 
   /**
    * optional. If this is passed, its value will take precedence over your sandbox connection settings `includeCookies` value.
@@ -128,6 +134,7 @@ export class EmbeddedSandbox {
     this.disposable = setupSandboxEmbedRelay({
       embeddedSandboxIFrameElement: this.embeddedSandboxIFrameElement,
       handleRequest: this.handleRequest,
+      modifyHeaders: this.options.modifyHeaders,
       __testLocal__: !!this.__testLocal__,
     });
   }

--- a/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
+++ b/packages/sandbox/src/helpers/postMessageRelayHelpers.ts
@@ -41,6 +41,10 @@ export type HandleRequest = (
   endpointUrl: string,
   options: Omit<RequestInit, 'headers'> & { headers: Record<string, string> }
 ) => Promise<Response>;
+export type ModifyHeaders = (
+  endpointUrl: string,
+  headers: Record<string, string> | undefined
+) => Promise<Record<string, string> | undefined>;
 
 export type SocketStatus = 'disconnected' | 'connecting' | 'connected';
 


### PR DESCRIPTION
Adding an optional function which can modify the headers before they are being sent.
It allows to add additional headers or modify existing headers like `Authorization`.

It can be used like this:
```js
new window.EmbeddedSandbox({
  target: '#sandbox',
  initialEndpoint: window.location.href,
  initialState: {
    sharedHeaders: {
      'X-SpecialHeader': 'WILL_BE_REPLACED_AUTOMATICALLY'
    }
  },
  modifyHeaders: async (url, headers) => {
    // Add Authorization header if not provided
    if (!headers.Authorization) {
      const accessToken = await window.getAccessToken();
      headers.Authorization = 'Bearer ' + accessToken;
    }
    // Modify special header if shared header is not unchecked
    if (headers['X-SpecialHeader'] === 'WILL_BE_REPLACED_AUTOMATICALLY') {
      const special = await window.getTheValue();
      headers['X-SpecialHeader'] = special;
    }
    return headers;
  }
});
```

closes #308
replaces #307 